### PR TITLE
0.3.5.post2 - fix minor logging bug: NoneType: None

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,8 @@ tokens*.*
 *.old
 *.out
 *.txt
-.vscode/*
+.secrets/
+.vscode/
 
 
 ### github's default .gitignore file

--- a/evohomeasync/__init__.py
+++ b/evohomeasync/__init__.py
@@ -193,8 +193,7 @@ class EvohomeClient(object):  # pylint: disable=useless-object-inheritance
                     _LOGGER.error(
                         "HTTP Status = %s, Response = %s",
                         response.status,
-                        response_text,
-                        exc_info=True
+                        response_text
                     )
 
             response.raise_for_status()

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup
 from setuptools.command.install import install
 
-VERSION = "0.3.5.post1"
+VERSION = "0.3.5.post2"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()


### PR DESCRIPTION
Gets rid of the `NoneType: None`:
```text
2020-01-25 08:54:08 DEBUG (MainThread) [evohomeasync] Session expired, re-authenticating...
2020-01-25 08:54:09 ERROR (MainThread) [evohomeasync] HTTP Status = 429, Response = [
  {
    "code": "TooManyRequests",
    "message": "Request count limitation exceeded, please try again later."
  }
]
NoneType: None
2020-01-25 08:54:10 DEBUG (MainThread) [evohomeasync] ...
``