### PR TITLE
Adjust hatchling path to ensure deployment of evohomeasync directories.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@
   sources = ["src"]
 
 [tool.hatch.build.targets.wheel]
-  packages = ["src/evohomeasync", "src/evohomeasync2"]
+  packages = ["evohomeasync", "evohomeasync2"]
 
 [tool.hatch.version]
   path = "src/evohomeasync2/__init__.py"


### PR DESCRIPTION
I'm working on a Yocto based version of HomeAssistant. I was creating a recipe to build and install evohome-async and noticed that the `lib/python3.12/site-packages/` were not being populated by the `evohomeasync` and `evohomeasync2` folders.  After some googling I found this issue and it seems eerily similar to what I see happening: https://github.com/home-assistant/core/issues/123955

To fix this a slight modification of the **pyproject.toml** file is needed.

```
[tool.hatch.build.targets.wheel]
  packages = ["evohomeasync", "evohomeasync2"]
```
... instead of 
```
[tool.hatch.build.targets.wheel]
  packages = ["src/evohomeasync", "src/evohomeasync2"]
```

This causes hatchling to correctly deploy the files into the `site-packages` folders.