### PR TITLE
Fix argument for aiofiles.open()

### DIFF
--- a/src/evohomeasync2/client.py
+++ b/src/evohomeasync2/client.py
@@ -93,7 +93,7 @@ async def _write(filename: TextIOWrapper | Any, content: str) -> None:
     """Write to a file, async if possible and sync otherwise."""
 
     try:
-        async with aiofiles.open(filename, "w") as fp:  # type: ignore[call-overload]
+        async with aiofiles.open(filename.name, "w") as fp:  # type: ignore[call-overload]
             await fp.write(content)
     except TypeError:  # if filename is sys.stdout:
         filename.write(content)
@@ -358,7 +358,7 @@ async def set_schedules(
     evo: EvohomeClient = ctx.obj[SZ_EVO]
 
     # will TypeError if filename is sys.stdin
-    async with aiofiles.open(filename) as fp:  # type: ignore[call-overload]
+    async with aiofiles.open(filename.name) as fp:  # type: ignore[call-overload]
         content = await fp.read()
 
     success = await _get_tcs(evo, loc_idx).set_schedules(json.loads(content))


### PR DESCRIPTION
Hi, I was trying to download and upload the schedules. I received the following error when uploading:
```
[...]
File "[...]/evohome-async/src/evohomeasync2/client.py", line 361, in set_schedules
    async with aiofiles.open(filename) as fp:  # type: ignore[call-overload]
[...]
TypeError: expected str, bytes or os.PathLike object, not TextIOWrapper
```

The change in this PR resolved the error for me, but I haven't deep-dived on what the ideal fix is.

I installed the dependencies from `requirements_dev.txt`. My Click versions:
```
asyncclick==8.1.7.2
click==8.1.7
```