### PR TITLE
ci: add HA compliance workflow and checks

### DIFF
--- a/.github/scripts/check_ha_compliance.py
+++ b/.github/scripts/check_ha_compliance.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""HA platinum quality scale compliance checks."""
+
+from __future__ import annotations
+
+import http.client
+import re
+import sys
+import tomllib
+import urllib.parse
+import zipfile
+from pathlib import Path
+from typing import NoReturn
+
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+HA_STABLE_PYPROJECT = (
+    "https://raw.githubusercontent.com/home-assistant/core/master/pyproject.toml"
+)
+LIB_SRC = Path("src")
+EXCLUDED_PARTS = {"evohome_cli", "tests", "test"}
+EXPECTED_ARGC = 2
+
+
+def _echo(message: str) -> None:
+    sys.stdout.write(f"{message}\n")
+
+
+def _fail(message: str) -> NoReturn:
+    sys.stderr.write(f"{message}\n")
+    raise SystemExit(1)
+
+
+def _load_pyproject(path: Path) -> dict[str, object]:
+    with path.open("rb") as file:
+        return tomllib.load(file)
+
+
+def load_our_pyproject() -> dict[str, object]:
+    return _load_pyproject(Path("pyproject.toml"))
+
+
+def load_ha_pyproject() -> dict[str, object]:
+    parsed = urllib.parse.urlsplit(HA_STABLE_PYPROJECT)
+    if parsed.scheme != "https" or parsed.netloc != "raw.githubusercontent.com":
+        _fail(f"FAIL: unsupported HA pyproject URL: {HA_STABLE_PYPROJECT}")
+
+    connection = http.client.HTTPSConnection(parsed.netloc, timeout=30)
+    try:
+        connection.request("GET", parsed.path)
+        response = connection.getresponse()
+        if response.status != http.client.OK:
+            _fail(
+                "FAIL: could not fetch HA pyproject "
+                f"(HTTP {response.status} {response.reason})"
+            )
+        return tomllib.loads(response.read().decode("utf-8"))
+    finally:
+        connection.close()
+
+
+def _project_dependencies(data: dict[str, object]) -> list[str]:
+    project = data.get("project")
+    if not isinstance(project, dict):
+        return []
+    dependencies = project.get("dependencies", [])
+    if not isinstance(dependencies, list):
+        return []
+    return [dep for dep in dependencies if isinstance(dep, str)]
+
+
+def _project_requires_python(data: dict[str, object]) -> str:
+    project = data.get("project")
+    if not isinstance(project, dict):
+        return ""
+
+    requires_python = project.get("requires-python", "")
+    if not isinstance(requires_python, str):
+        return ""
+    return requires_python.strip()
+
+
+def _normalize_name(name: str) -> str:
+    return name.strip().lower().replace("_", "-")
+
+
+def _iter_library_files() -> list[Path]:
+    files = []
+    for path in LIB_SRC.rglob("*.py"):
+        if any(part in EXCLUDED_PARTS for part in path.parts):
+            continue
+        files.append(path)
+    return files
+
+
+def _highest_lower_bound(requirement: Requirement) -> Version | None:
+    lower_bound: Version | None = None
+    for specifier in requirement.specifier:
+        if specifier.operator != ">=":
+            continue
+        version = Version(specifier.version)
+        if lower_bound is None or version > lower_bound:
+            lower_bound = version
+    return lower_bound
+
+
+def check_no_exact_pins() -> None:
+    deps = _project_dependencies(load_our_pyproject())
+    exact_pins: list[str] = []
+    unsupported: list[str] = []
+
+    for dep in deps:
+        requirement = Requirement(dep)
+        for specifier in requirement.specifier:
+            if specifier.operator in {"==", "==="}:
+                exact_pins.append(dep)
+            if specifier.operator not in {">=", "!="}:
+                unsupported.append(dep)
+
+    if exact_pins:
+        _echo("FAIL: exact pins (==) found in [project].dependencies:")
+        for dep in exact_pins:
+            _echo(f"  - {dep}")
+        raise SystemExit(1)
+
+    if unsupported:
+        _echo("FAIL: unsupported dependency operators found.")
+        _echo("Use >= floor constraints (and optional != exclusions) only:")
+        for dep in sorted(set(unsupported)):
+            _echo(f"  - {dep}")
+        raise SystemExit(1)
+
+    _echo(f"OK: dependency constraints are floor-based across {len(deps)} entries")
+
+
+def check_dep_ceiling() -> None:
+    our_deps = _project_dependencies(load_our_pyproject())
+    ha_deps = _project_dependencies(load_ha_pyproject())
+
+    ha_pins: dict[str, Version] = {}
+    for dep in ha_deps:
+        requirement = Requirement(dep)
+        exact_versions = [
+            Version(specifier.version)
+            for specifier in requirement.specifier
+            if specifier.operator == "=="
+        ]
+        if exact_versions:
+            ha_pins[_normalize_name(requirement.name)] = max(exact_versions)
+
+    failures: list[str] = []
+    for dep in our_deps:
+        requirement = Requirement(dep)
+        name = _normalize_name(requirement.name)
+        our_floor = _highest_lower_bound(requirement)
+        if our_floor is None:
+            continue
+
+        ha_pin = ha_pins.get(name)
+        if ha_pin is None:
+            _echo(f"OK: {name}>={our_floor} (not pinned by HA, skipped)")
+            continue
+
+        if our_floor > ha_pin:
+            failures.append(f"  {name}>={our_floor} exceeds HA stable pin {ha_pin}")
+            continue
+
+        _echo(f"OK: {name}>={our_floor} <= HA stable {ha_pin}")
+
+    if failures:
+        _echo("FAIL: these dependency floors exceed HA current stable pins:")
+        for failure in failures:
+            _echo(failure)
+        raise SystemExit(1)
+
+
+def check_async_dep() -> None:
+    failures: list[str] = []
+    for path in _iter_library_files():
+        text = path.read_text(encoding="utf-8")
+        for line_no, line in enumerate(text.splitlines(), 1):
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue
+            if "import requests" in line:
+                failures.append(f"  {path}:{line_no}: 'import requests' (use aiohttp)")
+            if "time.sleep(" in line:
+                failures.append(
+                    f"  {path}:{line_no}: 'time.sleep()' (use asyncio.sleep)"
+                )
+
+    if failures:
+        _echo("FAIL: blocking I/O found in library source:")
+        for failure in failures:
+            _echo(failure)
+        raise SystemExit(1)
+
+    _echo("OK: no blocking I/O found in library source")
+
+
+def check_inject_websession() -> None:
+    failures: list[str] = []
+    for path in _iter_library_files():
+        text = path.read_text(encoding="utf-8")
+        for line_no, line in enumerate(text.splitlines(), 1):
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue
+            if "aiohttp.ClientSession()" in line:
+                failures.append(
+                    f"  {path}:{line_no}: internal aiohttp.ClientSession() construction"
+                )
+
+    if failures:
+        _echo("FAIL: internal ClientSession construction found:")
+        for failure in failures:
+            _echo(failure)
+        raise SystemExit(1)
+
+    _echo("OK: no internal ClientSession construction found")
+
+
+def check_py_typed() -> None:
+    markers = [
+        path
+        for path in LIB_SRC.rglob("py.typed")
+        if not any(part in EXCLUDED_PARTS for part in path.parts)
+    ]
+    if not markers:
+        _fail(f"FAIL: no py.typed marker found under {LIB_SRC}/")
+
+    _echo(f"OK: py.typed found at {markers[0]}")
+
+
+def check_python_versions() -> None:
+    ha_pyproject = load_ha_pyproject()
+    our_pyproject = load_our_pyproject()
+
+    ha_requires = _project_requires_python(ha_pyproject)
+    our_requires = _project_requires_python(our_pyproject)
+
+    ha_match = re.search(r"3\.(\d+)", ha_requires)
+    our_match = re.search(r"3\.(\d+)", our_requires)
+
+    if not ha_match:
+        _fail(f"FAIL: could not parse HA requires-python: {ha_requires}")
+    if not our_match:
+        _fail(f"FAIL: could not parse our requires-python: {our_requires}")
+
+    ha_minor = int(ha_match.group(1))
+    our_minor_floor = int(our_match.group(1))
+
+    if our_minor_floor > ha_minor - 1:
+        _fail(
+            f"FAIL: requires-python='{our_requires}' does not cover "
+            f"HA previous minor 3.{ha_minor - 1}"
+        )
+
+    _echo(
+        f"OK: requires-python='{our_requires}' covers HA previous/current "
+        f"minor versions (3.{ha_minor - 1}, 3.{ha_minor})"
+    )
+
+
+def check_py_typed_wheel() -> None:
+    dist_dir = Path("dist")
+    wheels = sorted(dist_dir.glob("*.whl"))
+    if not wheels:
+        _fail("FAIL: no wheel found in dist/")
+
+    found = False
+    for wheel in wheels:
+        with zipfile.ZipFile(wheel) as archive:
+            if any(member.endswith("/py.typed") for member in archive.namelist()):
+                found = True
+                break
+
+    if not found:
+        _fail("FAIL: py.typed missing from built wheel")
+
+    _echo("OK: py.typed found in built wheel")
+
+
+COMMANDS = {
+    "no-exact-pins": check_no_exact_pins,
+    "dep-ceiling": check_dep_ceiling,
+    "async-dep": check_async_dep,
+    "inject-websession": check_inject_websession,
+    "py-typed": check_py_typed,
+    "python-versions": check_python_versions,
+    "py-typed-wheel": check_py_typed_wheel,
+}
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != EXPECTED_ARGC or sys.argv[1] not in COMMANDS:
+        _echo(f"Usage: check_ha_compliance.py <{'|'.join(COMMANDS)}>")
+        raise SystemExit(2)
+    COMMANDS[sys.argv[1]]()

--- a/.github/workflows/ha-compliance.yml
+++ b/.github/workflows/ha-compliance.yml
@@ -1,0 +1,92 @@
+name: ha-compliance
+
+on:
+  push:
+    branches: ["main", "dev"]
+  pull_request:
+    branches: ["main", "dev"]
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-transparency:
+    name: "Rule: dependency-transparency"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+          check-latest: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install compliance check dependencies
+        run: uv pip install --system build packaging
+
+      - name: Check no exact pins (==) in library dependencies
+        run: python .github/scripts/check_ha_compliance.py no-exact-pins
+
+      - name: Check dependency floors do not exceed HA stable pin
+        run: python .github/scripts/check_ha_compliance.py dep-ceiling
+
+      - name: Build wheel
+        run: python -m build --wheel --no-isolation
+
+      - name: Check py.typed present in built wheel
+        run: python .github/scripts/check_ha_compliance.py py-typed-wheel
+
+  async-dependency:
+    name: "Rule: async-dependency"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check for blocking I/O in library source
+        run: python .github/scripts/check_ha_compliance.py async-dep
+
+  inject-websession:
+    name: "Rule: inject-websession"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check no internal ClientSession construction
+        run: python .github/scripts/check_ha_compliance.py inject-websession
+
+  strict-typing:
+    name: "Rule: strict-typing"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+          check-latest: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install project dependencies
+        run: uv pip install --system -e .[cli,dev]
+
+      - name: Install compliance check dependencies
+        run: uv pip install --system packaging
+
+      - name: Check py.typed marker exists in source
+        run: python .github/scripts/check_ha_compliance.py py-typed
+
+      - name: Check Python version coverage (HA current + previous)
+        run: python .github/scripts/check_ha_compliance.py python-versions
+
+      - name: mypy --strict src/
+        run: mypy --strict src/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 authors = [{ name = "David Bonnes", email = "zxdavb@bonnes.me" }]
 maintainers = [{ name = "David Bonnes", email = "zxdavb@bonnes.me" }]
 dependencies = ["aiohttp>=3.13.3", "aiozoneinfo>=0.2.3", "voluptuous>=0.15.2"]  # must support HA
-requires-python = ">=3.13.2"
+requires-python = ">=3.12"
 license = "Apache-2.0"
 
 keywords = [

--- a/src/evohomeasync/__init__.py
+++ b/src/evohomeasync/__init__.py
@@ -8,9 +8,7 @@ Further information at: https://evohome-client.readthedocs.io
 from __future__ import annotations
 
 from datetime import UTC, datetime as dt, timedelta as td
-from typing import Self
-
-import aiohttp
+from typing import TYPE_CHECKING, Self
 
 from .auth import AbstractSessionManager
 from .entities import ControlSystem, Gateway, HotWater, Location, Zone
@@ -62,6 +60,9 @@ from .schemas import (  # noqa: F401
     SZ_VALUE,
 )
 
+if TYPE_CHECKING:
+    from aiohttp import ClientSession
+
 
 class _SessionManager(AbstractSessionManager):  # used only by EvohomeClientOld
     """A TokenManager wrapper to help expose the refactored EvohomeClient."""
@@ -70,7 +71,7 @@ class _SessionManager(AbstractSessionManager):  # used only by EvohomeClientOld
         self,
         username: str,
         password: str,
-        websession: aiohttp.ClientSession,
+        websession: ClientSession,
         /,
         *,
         session_id: str | None = None,
@@ -102,13 +103,10 @@ class EvohomeClientOld(EvohomeClient):
         /,
         *,
         session_id: str | None = None,
-        websession: aiohttp.ClientSession | None = None,
+        websession: ClientSession,
         debug: bool = False,
     ) -> None:
         """Construct the v0 EvohomeClient object."""
-        self._owns_session = websession is None
-        websession = websession or aiohttp.ClientSession()
-
         self._session_manager = _SessionManager(
             username,
             password,
@@ -118,9 +116,7 @@ class EvohomeClientOld(EvohomeClient):
         super().__init__(self._session_manager, debug=debug)
 
     async def close(self) -> None:
-        """Close the owned aiohttp.ClientSession, if any."""
-        if self._owns_session:
-            await self._session_manager.websession.close()
+        """Close the client wrapper."""
 
     async def __aenter__(self) -> Self:
         return self

--- a/src/evohomeasync2/__init__.py
+++ b/src/evohomeasync2/__init__.py
@@ -8,9 +8,7 @@ Further information at: https://evohome-client.readthedocs.io
 from __future__ import annotations
 
 from datetime import UTC, datetime as dt
-from typing import Self
-
-import aiohttp
+from typing import TYPE_CHECKING, Self
 
 from .auth import AbstractTokenManager
 from .control_system import ControlSystem
@@ -40,6 +38,9 @@ from .location import Location
 from .main import EvohomeClient
 from .zone import Zone
 
+if TYPE_CHECKING:
+    from aiohttp import ClientSession
+
 
 class _TokenManager(AbstractTokenManager):  # used only by EvohomeClientOld
     """A TokenManager wrapper to help expose the refactored EvohomeClient."""
@@ -48,7 +49,7 @@ class _TokenManager(AbstractTokenManager):  # used only by EvohomeClientOld
         self,
         username: str,
         password: str,
-        websession: aiohttp.ClientSession,
+        websession: ClientSession,
         /,
         *,
         access_token: str | None = None,
@@ -87,13 +88,10 @@ class EvohomeClientOld(EvohomeClient):
         refresh_token: str | None = None,
         access_token: str | None = None,
         access_token_expires: dt | None = None,
-        websession: aiohttp.ClientSession | None = None,
+        websession: ClientSession,
         debug: bool = False,
     ) -> None:
         """Construct the v2 EvohomeClient object."""
-        self._owns_session = websession is None
-        websession = websession or aiohttp.ClientSession()
-
         self._token_manager = _TokenManager(
             username,
             password,
@@ -105,9 +103,7 @@ class EvohomeClientOld(EvohomeClient):
         super().__init__(self._token_manager, debug=debug)
 
     async def close(self) -> None:
-        """Close the owned aiohttp.ClientSession, if any."""
-        if self._owns_session:
-            await self._token_manager.websession.close()
+        """Close the client wrapper."""
 
     async def __aenter__(self) -> Self:
         return self


### PR DESCRIPTION
## Summary
- add reusable HA compliance workflow with four rule jobs
- add compliance checker script for dependency transparency, async dependency, websession injection, and strict typing checks
- enforce injected websession in legacy wrapper constructors to satisfy inject-websession rule
- align requires-python floor with HA current+previous minor coverage

## Changes
- add `.github/workflows/ha-compliance.yml`
- add `.github/scripts/check_ha_compliance.py`
- update `src/evohomeasync/__init__.py` to require injected websession in `EvohomeClientOld`
- update `src/evohomeasync2/__init__.py` to require injected websession in `EvohomeClientOld`
- update `pyproject.toml` `requires-python` from `>=3.13.2` to `>=3.12`

## Validation
- ruff check .
- ruff format --check .
- mypy
- pytest
- compliance script subcommands (all pass)
