### PR TITLE
Copilot/chunk 05 renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,29 +1,5 @@
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# Version updates disabled — managed by Renovate instead.
+# Security alerts from Dependabot remain active regardless of this file.
 
 version: 2
-
-updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    groups:
-      development-dependencies:
-        patterns:
-          - "pytest*"
-          - "ruff"
-          - "mypy"
-          - "types-*"
-        update-types:
-          - "minor"
-          - "patch"
-
-  - package-ecosystem: "github-actions"
-    directory: ".github/workflows"
-    schedule:
-      interval: "weekly"
-    groups:
-      actions:
-        patterns:
-          - "*"
+updates: []

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ tokens*
 
 # schedule backups
 /*.json
+!renovate.json
 
 # temporary: a WIP
 tests.*/

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+
+  "rangeStrategy": "bump",
+
+  "packageRules": [
+    {
+      "description": "Automerge minor and patch updates for Python deps and Actions",
+      "matchManagers": ["pep621", "github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash",
+      "addLabels": ["dependencies"]
+    },
+    {
+      "description": "Major updates require human review",
+      "matchManagers": ["pep621", "github-actions"],
+      "matchUpdateTypes": ["major"],
+      "automerge": false,
+      "addLabels": ["dependencies"]
+    },
+    {
+      "description": "Do not manage requires-python — handled manually per policy",
+      "matchDepTypes": ["requires-python"],
+      "enabled": false
+    },
+    {
+      "description": "Group all GitHub Actions updates into one PR",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "GitHub Actions",
+      "automerge": true
+    },
+    {
+      "description": "Group all Python dependency minor/patch updates into one PR",
+      "matchManagers": ["pep621"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "Python dependencies (minor/patch)",
+      "automerge": true
+    }
+  ],
+
+  "dependencyDashboard": true,
+  "dependencyDashboardTitle": "Renovate Dependency Dashboard",
+
+  "schedule": ["before 6am on Monday"],
+
+  "prConcurrentLimit": 5,
+
+  "commitMessagePrefix": "⬆️",
+  "commitMessageAction": "bump",
+
+  "ignorePaths": [
+    "**/node_modules/**"
+  ]
+}


### PR DESCRIPTION
This PR introduces Renovate-based dependency management (disabling Dependabot version-update PRs) and updates the project’s release/versioning automation to be tag- and VCS-driven.

Changes:

- Add renovate.json with automerge/grouping rules and disable Dependabot version updates.
- Switch package versioning from a hardcoded __version__ to hatch-vcs-generated version metadata.
- Replace/remove legacy release/tag workflows and add new tag validation, release drafting, and publish workflows (including reusable workflow support).