### PR TITLE
chore: block automerge for runtime deps (must track HA compatibility)

### DIFF
--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -7,21 +7,9 @@ name: Linting (ruff, codespell)
 on:
   pull_request:
     branches: [ "main", "dev" ]
-    paths: [
-      ".github/workflows/check-lint.yml",
-      "pyproject.toml",
-      "src/**.py",
-      "tests/**",
-    ]
 
   push:
     branches: [ "main", "dev" ]
-    paths: [
-      ".github/workflows/check-lint.yml",
-      "pyproject.toml",
-      "src/**.py",
-      "tests/**",
-    ]
 
   workflow_call:
 

--- a/.github/workflows/check-tests.yml
+++ b/.github/workflows/check-tests.yml
@@ -7,21 +7,9 @@ name: Testing (pytest)
 on:
   pull_request:
     branches: [ "main", "dev" ]
-    paths: [
-      ".github/workflows/check-tests.yml",
-      "pyproject.toml",
-      "src/**.py",
-      "tests/**",
-    ]
 
   push:
     branches: [ "main", "dev" ]
-    paths: [
-      ".github/workflows/check-tests.yml",
-      "pyproject.toml",
-      "src/**.py",
-      "tests/**",
-    ]
 
   schedule:
     - cron: "0 18 * * 5"  # Weekly on Friday

--- a/.github/workflows/check-type.yml
+++ b/.github/workflows/check-type.yml
@@ -7,23 +7,9 @@ name: Typing (mypy)
 on:
   pull_request:
     branches: [ "main", "dev" ]
-    paths: [
-      ".github/workflows/check-type.yml",
-      "pyproject.toml",
-      "src/**.py",
-      "src/**/py.typed",
-      "tests/**.py",
-    ]
 
   push:
     branches: [ "main", "dev" ]
-    paths: [
-      ".github/workflows/check-type.yml",
-      "pyproject.toml",
-      "src/**.py",
-      "src/**/py.typed",
-      "tests/**.py",
-    ]
 
   workflow_call:
 

--- a/renovate.json
+++ b/renovate.json
@@ -29,13 +29,6 @@
       "enabled": false
     },
     {
-      "description": "Runtime deps must stay compatible with HA — disable automerge, require human review",
-      "matchManagers": ["pep621"],
-      "matchDepTypes": ["project.dependencies"],
-      "automerge": false,
-      "addLabels": ["dependencies", "ha-compat-check"]
-    },
-    {
       "description": "Group all GitHub Actions updates into one PR",
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["minor", "patch"],
@@ -48,6 +41,13 @@
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "Python dependencies (minor/patch)",
       "automerge": true
+    },
+    {
+      "description": "Runtime deps must stay compatible with HA — disable automerge, require human review (must be last rule to override grouping rules above)",
+      "matchManagers": ["pep621"],
+      "matchDepTypes": ["project.dependencies"],
+      "automerge": false,
+      "addLabels": ["dependencies", "ha-compat-check"]
     }
   ],
 

--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,13 @@
       "enabled": false
     },
     {
+      "description": "Runtime deps must stay compatible with HA — disable automerge, require human review",
+      "matchManagers": ["pep621"],
+      "matchDepTypes": ["project.dependencies"],
+      "automerge": false,
+      "addLabels": ["dependencies", "ha-compat-check"]
+    },
+    {
       "description": "Group all GitHub Actions updates into one PR",
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
Add a Renovate `packageRule` that disables automerge for all `[project.dependencies]` updates.

These runtime deps (`aiohttp`, `aiozoneinfo`, `voluptuous`) must remain compatible with the versions pinned by Home Assistant core. Automerging minor/patch bumps is risky — e.g. Renovate currently proposes `voluptuous>=0.16.0` but HA `dev` is still on `0.15.2`.

Updates to runtime deps will still generate PRs (labelled `ha-compat-check`) but require a human to verify against HA's `package_constraints.txt` before merging.

Dev/CI dependencies (`[project.optional-dependencies].dev`) are unaffected and continue to automerge.