### PR TITLE
fix: use 'poetry' manager and disable runtime deps tracking in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,6 @@
   "packageRules": [
     {
       "description": "Automerge minor and patch updates for Python deps and Actions",
-      "matchManagers": ["poetry", "github-actions"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
       "automergeType": "pr",
@@ -18,7 +17,6 @@
     },
     {
       "description": "Major updates require human review",
-      "matchManagers": ["poetry", "github-actions"],
       "matchUpdateTypes": ["major"],
       "automerge": false,
       "addLabels": ["dependencies"]
@@ -37,7 +35,7 @@
     },
     {
       "description": "Group all Python dependency minor/patch updates into one PR",
-      "matchManagers": ["poetry"],
+      "matchCategories": ["python"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "Python dependencies (minor/patch)",
       "automerge": true

--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,13 @@
       "enabled": false
     },
     {
+      "description": "Runtime deps must stay compatible with HA — disable automerge, require human review",
+      "matchManagers": ["pep621"],
+      "matchDepTypes": ["project.dependencies"],
+      "automerge": false,
+      "addLabels": ["dependencies", "ha-compat-check"]
+    },
+    {
       "description": "Group all GitHub Actions updates into one PR",
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["minor", "patch"],

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
   "packageRules": [
     {
       "description": "Automerge minor and patch updates for Python deps and Actions",
-      "matchManagers": ["pep621", "github-actions"],
+      "matchManagers": ["poetry", "github-actions"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
       "automergeType": "pr",
@@ -18,7 +18,7 @@
     },
     {
       "description": "Major updates require human review",
-      "matchManagers": ["pep621", "github-actions"],
+      "matchManagers": ["poetry", "github-actions"],
       "matchUpdateTypes": ["major"],
       "automerge": false,
       "addLabels": ["dependencies"]
@@ -29,13 +29,6 @@
       "enabled": false
     },
     {
-      "description": "Runtime deps must stay compatible with HA — disable automerge, require human review",
-      "matchManagers": ["pep621"],
-      "matchDepTypes": ["project.dependencies"],
-      "automerge": false,
-      "addLabels": ["dependencies", "ha-compat-check"]
-    },
-    {
       "description": "Group all GitHub Actions updates into one PR",
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["minor", "patch"],
@@ -44,17 +37,15 @@
     },
     {
       "description": "Group all Python dependency minor/patch updates into one PR",
-      "matchManagers": ["pep621"],
+      "matchManagers": ["poetry"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "Python dependencies (minor/patch)",
       "automerge": true
     },
     {
-      "description": "Runtime deps must stay compatible with HA — disable automerge, require human review (must be last rule to override grouping rules above)",
-      "matchManagers": ["pep621"],
-      "matchDepTypes": ["project.dependencies"],
-      "automerge": false,
-      "addLabels": ["dependencies", "ha-compat-check"]
+      "description": "Runtime deps must stay compatible with HA — managed manually, not by Renovate",
+      "matchPackageNames": ["aiohttp", "aiozoneinfo", "voluptuous"],
+      "enabled": false
     }
   ],
 


### PR DESCRIPTION
Fixes two issues with the Renovate config merged in #60:

1. **Wrong manager name**: Renovate detects this repo's `pyproject.toml` as `poetry`, not `pep621`. All `matchManagers: [\"pep621\"]` references are replaced with `\"poetry\"`.

2. **Wrong suppression strategy**: Using `automerge: false` still causes runtime deps (`aiohttp`, `aiozoneinfo`, `voluptuous`) to appear in the dashboard. Replaced with `enabled: false` + `matchPackageNames` to remove them entirely — these are managed manually against HA's pinned versions.