### PR TITLE
Fix/renovate use poetry manager and disable runtime deps

### DIFF
--- a/.github/python-versions.json
+++ b/.github/python-versions.json
@@ -1,7 +1,0 @@
-{
-  "_note": "Fallback Python version list used when endoflife.date API is unavailable. Keep in sync with non-EOL CPython releases >= 3.13. Update when a new minor is released or a minor reaches EOL.",
-  "versions": [
-    "3.13.13",
-    "3.14.5"
-  ]
-}

--- a/.github/python-versions.json
+++ b/.github/python-versions.json
@@ -1,0 +1,7 @@
+{
+  "_note": "Fallback Python version list used when endoflife.date API is unavailable. Keep in sync with non-EOL CPython releases >= 3.13. Update when a new minor is released or a minor reaches EOL.",
+  "versions": [
+    "3.13.13",
+    "3.14.5"
+  ]
+}

--- a/.github/scripts/get-python-versions.py
+++ b/.github/scripts/get-python-versions.py
@@ -2,9 +2,9 @@
 """Build the Python test matrix for GitHub Actions.
 
 Queries endoflife.date for all non-EOL CPython versions >= the project's
-requires-python floor (read from pyproject.toml). Falls back to
-.github/python-versions.json if the API is unavailable. Also adds HA dev's
-required Python if it is a pre-release not yet listed on endoflife.date.
+requires-python floor (read from pyproject.toml). If the API is unavailable
+the script exits with an error. Also adds HA dev's required Python if it is
+a pre-release not yet listed on endoflife.date.
 
 Writes a JSON array to $GITHUB_OUTPUT as `matrix=["3.x.y", ...]`.
 """
@@ -12,7 +12,6 @@ Writes a JSON array to $GITHUB_OUTPUT as `matrix=["3.x.y", ...]`.
 import json
 import os
 import re
-import urllib.error
 import urllib.request
 from datetime import UTC, datetime as dt
 from pathlib import Path
@@ -28,25 +27,15 @@ if not _rp:
     raise ValueError("Could not parse requires-python from pyproject.toml")
 FLOOR = (int(_rp.group(1)), int(_rp.group(2)))
 
-# Versioned fallback — used if endoflife.date API is unavailable
-fallback: list[str] = json.loads((ROOT / ".github/python-versions.json").read_text())[
-    "versions"
-]
-
 # All non-EOL Python versions >= floor from endoflife.date
-try:
-    with urllib.request.urlopen(
-        "https://endoflife.date/api/python.json", timeout=10
-    ) as r:
-        cycles = json.loads(r.read())
-    today = dt.now(tz=UTC).date().isoformat()
-    versions: list[str] = sorted(
-        c["latest"]
-        for c in cycles
-        if c["eol"] > today and tuple(int(x) for x in c["cycle"].split(".")) >= FLOOR
-    )
-except (urllib.error.URLError, OSError, ValueError):
-    versions = fallback
+with urllib.request.urlopen("https://endoflife.date/api/python.json", timeout=10) as r:
+    cycles = json.loads(r.read())
+today = dt.now(tz=UTC).date().isoformat()
+versions: list[str] = sorted(
+    c["latest"]
+    for c in cycles
+    if c["eol"] > today and tuple(int(x) for x in c["cycle"].split(".")) >= FLOOR
+)
 
 # Also include HA dev's required Python if it's a pre-release not yet on endoflife.date
 try:

--- a/.github/scripts/get-python-versions.py
+++ b/.github/scripts/get-python-versions.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Build the Python test matrix for GitHub Actions.
+
+Queries endoflife.date for all non-EOL CPython versions >= the project's
+requires-python floor (read from pyproject.toml). Falls back to
+.github/python-versions.json if the API is unavailable. Also adds HA dev's
+required Python if it is a pre-release not yet listed on endoflife.date.
+
+Writes a JSON array to $GITHUB_OUTPUT as `matrix=["3.x.y", ...]`.
+"""
+
+import json
+import os
+import re
+import urllib.error
+import urllib.request
+from datetime import UTC, datetime as dt
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent  # repo root
+
+# Floor derived from requires-python in pyproject.toml — fail loudly if missing
+_rp = re.search(
+    r'requires-python\s*=\s*">=(\d+)\.(\d+)',
+    (ROOT / "pyproject.toml").read_text(),
+)
+if not _rp:
+    raise ValueError("Could not parse requires-python from pyproject.toml")
+FLOOR = (int(_rp.group(1)), int(_rp.group(2)))
+
+# Versioned fallback — used if endoflife.date API is unavailable
+fallback: list[str] = json.loads((ROOT / ".github/python-versions.json").read_text())[
+    "versions"
+]
+
+# All non-EOL Python versions >= floor from endoflife.date
+try:
+    with urllib.request.urlopen(
+        "https://endoflife.date/api/python.json", timeout=10
+    ) as r:
+        cycles = json.loads(r.read())
+    today = dt.now(tz=UTC).date().isoformat()
+    versions: list[str] = sorted(
+        c["latest"]
+        for c in cycles
+        if c["eol"] > today and tuple(int(x) for x in c["cycle"].split(".")) >= FLOOR
+    )
+except (urllib.error.URLError, OSError, ValueError):
+    versions = fallback
+
+# Also include HA dev's required Python if it's a pre-release not yet on endoflife.date
+try:
+    with urllib.request.urlopen(
+        "https://raw.githubusercontent.com/home-assistant/core/dev/pyproject.toml",
+        timeout=10,
+    ) as r:
+        content = r.read().decode()
+    m = re.search(r'requires-python\s*=\s*">=(\d+\.\d+)', content)
+    if m:
+        ha_minor = m.group(1)
+        if not any(v.startswith(ha_minor + ".") or v == ha_minor for v in versions):
+            versions.append(ha_minor)  # minor-only; allow-prereleases resolves latest
+            versions.sort()
+except (urllib.error.URLError, OSError, ValueError):
+    pass  # best-effort; HA's version is normally covered by endoflife.date
+
+with Path(os.environ["GITHUB_OUTPUT"]).open("a") as f:
+    f.write(f"matrix={json.dumps(versions)}\n")

--- a/.github/scripts/get-python-versions.py
+++ b/.github/scripts/get-python-versions.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Build the Python test matrix for GitHub Actions.
 
 Queries endoflife.date for all non-EOL CPython versions >= the project's
@@ -12,6 +11,7 @@ Writes a JSON array to $GITHUB_OUTPUT as `matrix=["3.x.y", ...]`.
 import json
 import os
 import re
+import urllib.error
 import urllib.request
 from datetime import UTC, datetime as dt
 from pathlib import Path

--- a/.github/scripts/get-python-versions.py
+++ b/.github/scripts/get-python-versions.py
@@ -16,7 +16,9 @@ import urllib.request
 from datetime import UTC, datetime as dt
 from pathlib import Path
 
-ROOT = Path(__file__).parent.parent  # repo root
+ROOT = Path(
+    __file__
+).parent.parent.parent  # repo root (.github/scripts/ -> .github/ -> root)
 
 # Floor derived from requires-python in pyproject.toml — fail loudly if missing
 _rp = re.search(

--- a/.github/workflows/check-hass-tests.yml
+++ b/.github/workflows/check-hass-tests.yml
@@ -107,6 +107,15 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: evohome-async
+          fetch-depth: 0  # Fetch all history for tags
+
+      - name: Checkout latest release tag (scheduled runs only)
+        if: github.event_name == 'schedule'
+        working-directory: evohome-async
+        run: |
+          LATEST_TAG=$(git describe --tags --abbrev=0)
+          echo "Checking out latest release: $LATEST_TAG"
+          git checkout "$LATEST_TAG"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0

--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.14"]
+        python-version: ["3.x"]
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/check-tests.yml
+++ b/.github/workflows/check-tests.yml
@@ -30,6 +30,8 @@ jobs:
     outputs:
       matrix: ${{ steps.build.outputs.matrix }}
     steps:
+      - uses: actions/checkout@v6
+
       - name: Query non-EOL Python versions >= 3.13
         id: build
         run: |
@@ -37,7 +39,10 @@ jobs:
           import json, re, urllib.error, urllib.request, datetime, os
 
           FLOOR = (3, 13)
-          FALLBACK = ["3.13", "3.14"]  # used if endoflife.date is unavailable
+
+          # Versioned fallback — used if endoflife.date API is unavailable
+          with open(".github/python-versions.json") as f:
+              fallback = json.load(f)["versions"]
 
           # All non-EOL Python versions >= 3.13 from endoflife.date
           try:
@@ -52,7 +57,7 @@ jobs:
                   and tuple(int(x) for x in c["cycle"].split(".")) >= FLOOR
               )
           except (urllib.error.URLError, OSError, ValueError):
-              versions = list(FALLBACK)  # fallback: minor-only; setup-python resolves latest patch
+              versions = fallback
 
           # Also include HA dev's required Python if it's a pre-release not yet on endoflife.date
           url = "https://raw.githubusercontent.com/home-assistant/core/dev/pyproject.toml"

--- a/.github/workflows/check-tests.yml
+++ b/.github/workflows/check-tests.yml
@@ -47,15 +47,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0  # Fetch all history for tags
-
-      - name: Checkout latest tag (scheduled runs only)
-        if: github.event_name == 'schedule'
-        run: |
-          LATEST_TAG=$(git describe --tags --abbrev=0)
-          echo "Checking out latest tag: $LATEST_TAG"
-          git checkout "$LATEST_TAG"
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6

--- a/.github/workflows/check-tests.yml
+++ b/.github/workflows/check-tests.yml
@@ -36,28 +36,36 @@ jobs:
           python3 - <<'EOF'
           import json, re, urllib.error, urllib.request, datetime, os
 
+          FLOOR = (3, 13)
+          FALLBACK = ["3.13", "3.14"]  # used if endoflife.date is unavailable
+
           # All non-EOL Python versions >= 3.13 from endoflife.date
-          with urllib.request.urlopen("https://endoflife.date/api/python.json") as r:
-              cycles = json.loads(r.read())
-          today = datetime.date.today().isoformat()
-          versions = sorted(
-              c["latest"] for c in cycles
-              if c["eol"] > today
-              and tuple(int(x) for x in c["cycle"].split(".")) >= (3, 13)
-          )
+          try:
+              with urllib.request.urlopen(
+                  "https://endoflife.date/api/python.json", timeout=10
+              ) as r:
+                  cycles = json.loads(r.read())
+              today = datetime.date.today().isoformat()
+              versions = sorted(
+                  c["latest"] for c in cycles
+                  if c["eol"] > today
+                  and tuple(int(x) for x in c["cycle"].split(".")) >= FLOOR
+              )
+          except (urllib.error.URLError, OSError, ValueError):
+              versions = list(FALLBACK)  # fallback: minor-only; setup-python resolves latest patch
 
           # Also include HA dev's required Python if it's a pre-release not yet on endoflife.date
           url = "https://raw.githubusercontent.com/home-assistant/core/dev/pyproject.toml"
           try:
-              with urllib.request.urlopen(url) as r:
+              with urllib.request.urlopen(url, timeout=10) as r:
                   content = r.read().decode()
               m = re.search(r'requires-python\s*=\s*">=(\d+\.\d+)', content)
               if m:
                   ha_minor = m.group(1)
-                  if not any(v.startswith(ha_minor + ".") for v in versions):
-                      versions.append(ha_minor + ".0")
+                  if not any(v.startswith(ha_minor + ".") or v == ha_minor for v in versions):
+                      versions.append(ha_minor)  # minor-only; allow-prereleases resolves latest
                       versions.sort()
-          except (urllib.error.URLError, ValueError):
+          except (urllib.error.URLError, OSError, ValueError):
               pass  # best-effort; HA's version is normally covered by endoflife.date
 
           with open(os.environ["GITHUB_OUTPUT"], "a") as f:

--- a/.github/workflows/check-tests.yml
+++ b/.github/workflows/check-tests.yml
@@ -24,13 +24,54 @@ permissions:
 
 
 jobs:
+  get-python-versions:
+    name: Build Python test matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.build.outputs.matrix }}
+    steps:
+      - name: Query non-EOL Python versions >= 3.13
+        id: build
+        run: |
+          python3 - <<'EOF'
+          import json, re, urllib.error, urllib.request, datetime, os
+
+          # All non-EOL Python versions >= 3.13 from endoflife.date
+          with urllib.request.urlopen("https://endoflife.date/api/python.json") as r:
+              cycles = json.loads(r.read())
+          today = datetime.date.today().isoformat()
+          versions = sorted(
+              c["latest"] for c in cycles
+              if c["eol"] > today
+              and tuple(int(x) for x in c["cycle"].split(".")) >= (3, 13)
+          )
+
+          # Also include HA dev's required Python if it's a pre-release not yet on endoflife.date
+          url = "https://raw.githubusercontent.com/home-assistant/core/dev/pyproject.toml"
+          try:
+              with urllib.request.urlopen(url) as r:
+                  content = r.read().decode()
+              m = re.search(r'requires-python\s*=\s*">=(\d+\.\d+)', content)
+              if m:
+                  ha_minor = m.group(1)
+                  if not any(v.startswith(ha_minor + ".") for v in versions):
+                      versions.append(ha_minor + ".0")
+                      versions.sort()
+          except (urllib.error.URLError, ValueError):
+              pass  # best-effort; HA's version is normally covered by endoflife.date
+
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"matrix={json.dumps(versions)}\n")
+          EOF
+
   test:
+    needs: get-python-versions
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && fromJSON('["3.13", "3.14", "3.15"]') || fromJSON('["3.13", "3.14"]') }}
+        python-version: ${{ fromJson(needs.get-python-versions.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v6
@@ -49,7 +90,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
-          check-latest: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0

--- a/.github/workflows/check-tests.yml
+++ b/.github/workflows/check-tests.yml
@@ -32,53 +32,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Query non-EOL Python versions >= 3.13
+      - name: Query non-EOL Python versions >= requires-python floor
         id: build
-        run: |
-          python3 - <<'EOF'
-          import json, re, urllib.error, urllib.request, datetime, os
-
-          # Floor derived from requires-python in pyproject.toml
-          with open("pyproject.toml") as f:
-              _rp = re.search(r'requires-python\s*=\s*">=(\d+)\.(\d+)', f.read())
-          FLOOR = (int(_rp.group(1)), int(_rp.group(2))) if _rp else (3, 13)
-
-          # Versioned fallback — used if endoflife.date API is unavailable
-          with open(".github/python-versions.json") as f:
-              fallback = json.load(f)["versions"]
-
-          # All non-EOL Python versions >= 3.13 from endoflife.date
-          try:
-              with urllib.request.urlopen(
-                  "https://endoflife.date/api/python.json", timeout=10
-              ) as r:
-                  cycles = json.loads(r.read())
-              today = datetime.date.today().isoformat()
-              versions = sorted(
-                  c["latest"] for c in cycles
-                  if c["eol"] > today
-                  and tuple(int(x) for x in c["cycle"].split(".")) >= FLOOR
-              )
-          except (urllib.error.URLError, OSError, ValueError):
-              versions = fallback
-
-          # Also include HA dev's required Python if it's a pre-release not yet on endoflife.date
-          url = "https://raw.githubusercontent.com/home-assistant/core/dev/pyproject.toml"
-          try:
-              with urllib.request.urlopen(url, timeout=10) as r:
-                  content = r.read().decode()
-              m = re.search(r'requires-python\s*=\s*">=(\d+\.\d+)', content)
-              if m:
-                  ha_minor = m.group(1)
-                  if not any(v.startswith(ha_minor + ".") or v == ha_minor for v in versions):
-                      versions.append(ha_minor)  # minor-only; allow-prereleases resolves latest
-                      versions.sort()
-          except (urllib.error.URLError, OSError, ValueError):
-              pass  # best-effort; HA's version is normally covered by endoflife.date
-
-          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
-              f.write(f"matrix={json.dumps(versions)}\n")
-          EOF
+        run: python3 .github/scripts/get-python-versions.py
 
   test:
     needs: get-python-versions

--- a/.github/workflows/check-tests.yml
+++ b/.github/workflows/check-tests.yml
@@ -38,7 +38,10 @@ jobs:
           python3 - <<'EOF'
           import json, re, urllib.error, urllib.request, datetime, os
 
-          FLOOR = (3, 13)
+          # Floor derived from requires-python in pyproject.toml
+          with open("pyproject.toml") as f:
+              _rp = re.search(r'requires-python\s*=\s*">=(\d+)\.(\d+)', f.read())
+          FLOOR = (int(_rp.group(1)), int(_rp.group(2))) if _rp else (3, 13)
 
           # Versioned fallback — used if endoflife.date API is unavailable
           with open(".github/python-versions.json") as f:

--- a/.github/workflows/check-tests.yml
+++ b/.github/workflows/check-tests.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Test with pytest
         env:
-          PYTEST_ADDOPTS: "--color=yes"
+          PYTEST_ADDOPTS: "--color=yes"  # cspell:ignore ADDOPTS, color
         run: pytest -v
 
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/check-type.yml
+++ b/.github/workflows/check-type.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.14"]
+        python-version: ["3.x"]
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/check-type.yml
+++ b/.github/workflows/check-type.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.x"]
+        python-version: ["3.13"]  # must match tool.mypy.python_version in pyproject.toml
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.14.5"
+          python-version: "3.14"
           check-latest: true
 
       - name: Install uv

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.14"
+          python-version: "3.x"
           check-latest: true
 
       - name: Install uv

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -52,6 +52,7 @@
         "deadband",
         "dehum",
         "EMEA",
+        "endoflife",
         "evohome",
         "evohomeasync",
         "evohomeclient",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,6 +203,7 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "./src/evohome_cli/client.py" = ["ARG001", "EXE001", "T10"]  # debugger, callbacks
 "./tests/*" = ["ARG", "SLF001"]  # tests need to access private members
+"./.github/scripts/*" = ["INP001"]  # standalone scripts, not a package
 
 [tool.ruff.lint.flake8-import-conventions.extend-aliases]
 voluptuous = "vol"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 authors = [{ name = "David Bonnes", email = "zxdavb@bonnes.me" }]
 maintainers = [{ name = "David Bonnes", email = "zxdavb@bonnes.me" }]
 dependencies = ["aiohttp>=3.13.5", "aiozoneinfo>=0.2.3", "voluptuous>=0.15.2"]  # must support HA
-requires-python = ">=3.13.2"
+requires-python = ">=3.13"
 license = "Apache-2.0"
 
 keywords = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 authors = [{ name = "David Bonnes", email = "zxdavb@bonnes.me" }]
 maintainers = [{ name = "David Bonnes", email = "zxdavb@bonnes.me" }]
 dependencies = ["aiohttp>=3.13.5", "aiozoneinfo>=0.2.3", "voluptuous>=0.15.2"]  # must support HA
-requires-python = ">=3.13"  # also see: tool_mypy.python_version, below
+requires-python = ">=3.13"  # also see: 'python_version', below, and typing workflow
 license = "Apache-2.0"
 
 keywords = [
@@ -94,7 +94,7 @@ version-file = "src/_evohome/_version.py"
 ### mypy #############################################################################
 
 [tool.mypy]
-python_version = "3.13"
+python_version = "3.13"  # see also: 'requires-python', above, and typing workflow
 
 strict = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 authors = [{ name = "David Bonnes", email = "zxdavb@bonnes.me" }]
 maintainers = [{ name = "David Bonnes", email = "zxdavb@bonnes.me" }]
 dependencies = ["aiohttp>=3.13.5", "aiozoneinfo>=0.2.3", "voluptuous>=0.15.2"]  # must support HA
-requires-python = ">=3.13"
+requires-python = ">=3.13"  # also see: tool_mypy.python_version, below
 license = "Apache-2.0"
 
 keywords = [

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,6 @@
   "packageRules": [
     {
       "description": "Automerge minor and patch updates for Python deps and Actions",
-      "matchManagers": ["poetry", "github-actions"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
       "automergeType": "pr",
@@ -18,7 +17,6 @@
     },
     {
       "description": "Major updates require human review",
-      "matchManagers": ["poetry", "github-actions"],
       "matchUpdateTypes": ["major"],
       "automerge": false,
       "addLabels": ["dependencies"]
@@ -37,7 +35,7 @@
     },
     {
       "description": "Group all Python dependency minor/patch updates into one PR",
-      "matchManagers": ["poetry"],
+      "matchCategories": ["python"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "Python dependencies (minor/patch)",
       "automerge": true

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
 
   "packageRules": [
     {
-      "description": "Automerge minor and patch updates for Python deps and Actions",
+      "description": "Automerge minor and patch updates for all Renovate-managed dependencies",
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
       "automergeType": "pr",
@@ -16,7 +16,7 @@
       "addLabels": ["dependencies"]
     },
     {
-      "description": "Major updates require human review",
+      "description": "Major updates require human review for all Renovate-managed dependencies",
       "matchUpdateTypes": ["major"],
       "automerge": false,
       "addLabels": ["dependencies"]

--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,13 @@
       "enabled": false
     },
     {
+      "description": "Runtime deps must stay compatible with HA — disable automerge, require human review",
+      "matchManagers": ["pep621"],
+      "matchDepTypes": ["project.dependencies"],
+      "automerge": false,
+      "addLabels": ["dependencies", "ha-compat-check"]
+    },
+    {
       "description": "Group all GitHub Actions updates into one PR",
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["minor", "patch"],

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
   "packageRules": [
     {
       "description": "Automerge minor and patch updates for Python deps and Actions",
-      "matchManagers": ["pep621", "github-actions"],
+      "matchManagers": ["poetry", "github-actions"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
       "automergeType": "pr",
@@ -18,7 +18,7 @@
     },
     {
       "description": "Major updates require human review",
-      "matchManagers": ["pep621", "github-actions"],
+      "matchManagers": ["poetry", "github-actions"],
       "matchUpdateTypes": ["major"],
       "automerge": false,
       "addLabels": ["dependencies"]
@@ -29,13 +29,6 @@
       "enabled": false
     },
     {
-      "description": "Runtime deps must stay compatible with HA — disable automerge, require human review",
-      "matchManagers": ["pep621"],
-      "matchDepTypes": ["project.dependencies"],
-      "automerge": false,
-      "addLabels": ["dependencies", "ha-compat-check"]
-    },
-    {
       "description": "Group all GitHub Actions updates into one PR",
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["minor", "patch"],
@@ -44,17 +37,15 @@
     },
     {
       "description": "Group all Python dependency minor/patch updates into one PR",
-      "matchManagers": ["pep621"],
+      "matchManagers": ["poetry"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "Python dependencies (minor/patch)",
       "automerge": true
     },
     {
-      "description": "Runtime deps must stay compatible with HA — disable automerge, require human review (must be last rule to override grouping rules above)",
-      "matchManagers": ["pep621"],
-      "matchDepTypes": ["project.dependencies"],
-      "automerge": false,
-      "addLabels": ["dependencies", "ha-compat-check"]
+      "description": "Runtime deps must stay compatible with HA — managed manually, not by Renovate",
+      "matchPackageNames": ["aiohttp", "aiozoneinfo", "voluptuous"],
+      "enabled": false
     }
   ],
 

--- a/renovate.json
+++ b/renovate.json
@@ -27,6 +27,12 @@
       "enabled": false
     },
     {
+      "description": "Python version inputs in workflows are managed dynamically — Renovate must not update them",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["python"],
+      "enabled": false
+    },
+    {
       "description": "Group all GitHub Actions updates into one PR",
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
## Pull request overview

This PR updates dependency and CI automation to reduce Renovate churn and make the Python test matrix follow currently-supported Python versions automatically.

**Changes:**
- Adjust Renovate rules to disable updates for selected runtime dependencies and workflow `python` inputs.
- Relax `requires-python` from `>=3.13.2` to `>=3.13`.
- Build the pytest workflow’s Python matrix dynamically via `endoflife.date` (+ a best-effort Home Assistant dev requirement probe), and use that matrix for tests.