### PR TITLE
fix: use matchDepNames for GitHub Actions python version disable rule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,7 +29,7 @@
     {
       "description": "Python version inputs in workflows are managed dynamically — Renovate must not update them",
       "matchManagers": ["github-actions"],
-      "matchPackageNames": ["python"],
+      "matchDepNames": ["python"],
       "enabled": false
     },
     {


### PR DESCRIPTION
Renovate was still creating PRs to pin `python-version: "3.x"` to a specific patch despite the `enabled: false` rule. Root cause: `matchPackageNames` does not reliably match against `depName` in this Renovate version. The correct field is `matchDepNames`.