### PR TITLE
fix: source aiohasupervisor from requirements_all.txt

### DIFF
--- a/.github/workflows/check-hass-tests.yml
+++ b/.github/workflows/check-hass-tests.yml
@@ -141,8 +141,10 @@ jobs:
           uv pip install -r requirements_test.txt
 
           # HA's tests/components/conftest.py imports aiohasupervisor at module level,
-          # so pytest collection fails without it, even for non-hassio component tests
-          uv pip install "$(grep '^aiohasupervisor' < requirements_test_all.txt)"
+          # so pytest collection fails without it, even for non-hassio component tests.
+          # requirements_test_all.txt was removed in home-assistant/core#171530;
+          # aiohasupervisor is now sourced from requirements_all.txt instead.
+          uv pip install "$(grep '^aiohasupervisor' < requirements_all.txt)"
 
           # Install Home Assistant in editable mode (needed for compiled translations)
           uv pip install -e . --config-settings editable_mode=compat


### PR DESCRIPTION
HA removed \`requirements_test_all.txt\` in [home-assistant/core#171530](https://github.com/home-assistant/core/pull/171530).

Our \`check-hass-tests.yml\` greps \`aiohasupervisor\` from that file to satisfy a module-level import in \`tests/components/conftest.py\`. With the file gone the workflow fails.

Fix: grep from \`requirements_all.txt\` instead, which still exists and contains all component dependencies including \`aiohasupervisor\`.