### PR TITLE
Ci: refactor workflows

### DIFF
--- a/.github/workflows/check-hass-tests.yml
+++ b/.github/workflows/check-hass-tests.yml
@@ -6,10 +6,11 @@
 #   ha_repo    — The GitHub repository to test against (default: vars.HA_REPO_DEFAULT).
 #                Change this to a fork, e.g. "zxdavb/core", for pre-merge testing.
 #
-#   ha_version — The branch, tag, or SHA to check out from ha_repo (default: vars.HA_VERSION_DEFAULT).
+#   ha_version — The branch, tag, SHA, or "latest" to check out from ha_repo.
 #                Common values:
+#                  "latest"    — latest HA release tag (resolved at runtime; default for workflow_call)
 #                  "master"    — HA's main development branch (tip of tree)
-#                  "dev"       — HA's dev branch (used in publish-release.yml as informational)
+#                  "dev"       — HA's dev branch
 #                  "2025.1"    — a specific HA release branch
 #                  "v2025.1.0" — a specific release tag
 #
@@ -18,8 +19,8 @@
 #   HA_VERSION_DEFAULT — default value for ha_version (e.g. "master")
 #
 # When triggered by `schedule`, these parameters are ignored and the defaults apply.
-# When called from publish-release.yml, ha_version is set to the latest HA release tag (dynamically
-# resolved) for the stable job, and "dev" for the informational job.
+# When called from publish-release.yml, ha_version defaults to "latest" (resolved at runtime to the
+# latest release tag) for the stable job, and "dev" for the informational job.
 
 name: Test with Home Assistant
 
@@ -52,9 +53,9 @@ on:
         default: "home-assistant/core"
         type: string
       ha_version:
-        description: "Home Assistant version/branch to test against"
+        description: "Home Assistant version/branch/tag or \"latest\" to test against"
         required: false
-        default: "master"
+        default: "latest"
         type: string
 
   workflow_dispatch:
@@ -77,7 +78,6 @@ permissions:
 
 env:
   HA_REPO: ${{ inputs.ha_repo || vars.HA_REPO_DEFAULT }}
-  HA_VERSION: ${{ inputs.ha_version || vars.HA_VERSION_DEFAULT }}
 
 
 jobs:
@@ -85,13 +85,28 @@ jobs:
     name: Get Python version from ${{ inputs.ha_repo || vars.HA_REPO_DEFAULT }}@${{ inputs.ha_version || vars.HA_VERSION_DEFAULT }}
     runs-on: ubuntu-latest
     outputs:
+      ha_version: ${{ steps.resolve-ha.outputs.ha_version }}
       python-version: ${{ steps.get-version.outputs.python-version }}
     steps:
-      - name: Check out ${{ env.HA_REPO }}@${{ env.HA_VERSION }} (sparse checkout of pyproject.toml)
+      - name: Resolve HA version
+        id: resolve-ha
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_VERSION: ${{ inputs.ha_version || vars.HA_VERSION_DEFAULT }}
+        run: |
+          if [[ "$INPUT_VERSION" == "latest" ]]; then
+            HA_VERSION=$(gh api repos/home-assistant/core/releases --jq '.[0].tag_name')
+            echo "Resolved 'latest' to: ${HA_VERSION}"
+          else
+            HA_VERSION="$INPUT_VERSION"
+          fi
+          echo "ha_version=${HA_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Check out ${{ env.HA_REPO }}@${{ steps.resolve-ha.outputs.ha_version }} (sparse checkout of pyproject.toml)
         uses: actions/checkout@v6
         with:
           repository: ${{ env.HA_REPO }}
-          ref: ${{ env.HA_VERSION }}
+          ref: ${{ steps.resolve-ha.outputs.ha_version }}
           sparse-checkout: pyproject.toml
           sparse-checkout-cone-mode: false
 
@@ -104,9 +119,11 @@ jobs:
           echo "Detected Python version: ${python_version}"
 
   test-with-hass:
-    name: Test with ${{ inputs.ha_repo || vars.HA_REPO_DEFAULT }}@${{ inputs.ha_version || vars.HA_VERSION_DEFAULT }} (Python ${{ needs.get-python-version.outputs.python-version }})
+    name: Test with ${{ inputs.ha_repo || vars.HA_REPO_DEFAULT }}@${{ needs.get-python-version.outputs.ha_version }} (Python ${{ needs.get-python-version.outputs.python-version }})
     runs-on: ubuntu-latest
     needs: get-python-version
+    env:
+      HA_VERSION: ${{ needs.get-python-version.outputs.ha_version }}
 
     steps:
       - name: Set up Python ${{ needs.get-python-version.outputs.python-version }}

--- a/.github/workflows/check-hass-tests.yml
+++ b/.github/workflows/check-hass-tests.yml
@@ -3,15 +3,19 @@
 #
 # KEY PARAMETERS (workflow_dispatch / workflow_call inputs; see the `on:` section below):
 #
-#   ha_repo    — The GitHub repository to test against (default: "home-assistant/core").
+#   ha_repo    — The GitHub repository to test against (default: vars.HA_REPO_DEFAULT).
 #                Change this to a fork, e.g. "zxdavb/core", for pre-merge testing.
 #
-#   ha_version — The branch, tag, or SHA to check out from ha_repo (default: "master").
+#   ha_version — The branch, tag, or SHA to check out from ha_repo (default: vars.HA_VERSION_DEFAULT).
 #                Common values:
 #                  "master"    — HA's main development branch (tip of tree)
 #                  "dev"       — HA's dev branch (used in publish-release.yml as informational)
 #                  "2025.1"    — a specific HA release branch
 #                  "v2025.1.0" — a specific release tag
+#
+# REPOSITORY VARIABLES (set in GitHub Settings → Secrets and variables → Actions → Variables):
+#   HA_REPO_DEFAULT    — default value for ha_repo    (e.g. "home-assistant/core")
+#   HA_VERSION_DEFAULT — default value for ha_version (e.g. "master")
 #
 # When triggered by `schedule`, these parameters are ignored and the defaults apply.
 # When called from publish-release.yml, ha_version is set explicitly (see that workflow).
@@ -71,13 +75,13 @@ permissions:
 
 
 env:
-  HA_REPO: ${{ inputs.ha_repo || 'home-assistant/core' }}
-  HA_VERSION: ${{ inputs.ha_version || 'master' }}
+  HA_REPO: ${{ inputs.ha_repo || vars.HA_REPO_DEFAULT }}
+  HA_VERSION: ${{ inputs.ha_version || vars.HA_VERSION_DEFAULT }}
 
 
 jobs:
   get-python-version:
-    name: Get Python version from ${{ inputs.ha_repo || 'home-assistant/core' }}@${{ inputs.ha_version || 'master' }}
+    name: Get Python version from ${{ inputs.ha_repo || vars.HA_REPO_DEFAULT }}@${{ inputs.ha_version || vars.HA_VERSION_DEFAULT }}
     runs-on: ubuntu-latest
     outputs:
       python-version: ${{ steps.get-version.outputs.python-version }}
@@ -99,7 +103,7 @@ jobs:
           echo "Detected Python version: ${python_version}"
 
   test-with-hass:
-    name: Test with ${{ inputs.ha_repo || 'home-assistant/core' }}@${{ inputs.ha_version || 'master' }} (Python ${{ needs.get-python-version.outputs.python-version }})
+    name: Test with ${{ inputs.ha_repo || vars.HA_REPO_DEFAULT }}@${{ inputs.ha_version || vars.HA_VERSION_DEFAULT }} (Python ${{ needs.get-python-version.outputs.python-version }})
     runs-on: ubuntu-latest
     needs: get-python-version
 

--- a/.github/workflows/check-hass-tests.yml
+++ b/.github/workflows/check-hass-tests.yml
@@ -1,5 +1,20 @@
-# This workflow tests the evohome-async library against Home Assistant's evohome integration tests
-# It clones Home Assistant core, installs this library, and runs the evohome component tests
+# This workflow tests the evohome-async library against Home Assistant's evohome integration tests.
+# It clones Home Assistant core, installs this library, and runs the evohome component tests.
+#
+# KEY PARAMETERS (workflow_dispatch / workflow_call inputs; see the `on:` section below):
+#
+#   ha_repo    — The GitHub repository to test against (default: "home-assistant/core").
+#                Change this to a fork, e.g. "zxdavb/core", for pre-merge testing.
+#
+#   ha_version — The branch, tag, or SHA to check out from ha_repo (default: "master").
+#                Common values:
+#                  "master"    — HA's main development branch (tip of tree)
+#                  "dev"       — HA's dev branch (used in publish-release.yml as informational)
+#                  "2025.1"    — a specific HA release branch
+#                  "v2025.1.0" — a specific release tag
+#
+# When triggered by `schedule`, these parameters are ignored and the defaults apply.
+# When called from publish-release.yml, ha_version is set explicitly (see that workflow).
 
 name: Test with Home Assistant
 
@@ -62,7 +77,7 @@ env:
 
 jobs:
   get-python-version:
-    name: Get Python version from HA
+    name: Get Python version from ${{ inputs.ha_repo || 'home-assistant/core' }}@${{ inputs.ha_version || 'master' }}
     runs-on: ubuntu-latest
     outputs:
       python-version: ${{ steps.get-version.outputs.python-version }}
@@ -84,7 +99,7 @@ jobs:
           echo "Detected Python version: ${python_version}"
 
   test-with-hass:
-    name: Test with HA (Python ${{ needs.get-python-version.outputs.python-version }})
+    name: Test with ${{ inputs.ha_repo || 'home-assistant/core' }}@${{ inputs.ha_version || 'master' }} (Python ${{ needs.get-python-version.outputs.python-version }})
     runs-on: ubuntu-latest
     needs: get-python-version
 
@@ -145,6 +160,7 @@ jobs:
           # beyond requirements.txt + requirements_test.txt:
           #   - aiohasupervisor: imported at module level in tests/components/conftest.py
           #   - paho-mqtt: imported at module level in tests/common.py (line 32)
+
           grep -E '^(aiohasupervisor|paho-mqtt)==' requirements_all.txt | xargs -d '\n' uv pip install
 
           # Install Home Assistant in editable mode (needed for compiled translations)

--- a/.github/workflows/check-hass-tests.yml
+++ b/.github/workflows/check-hass-tests.yml
@@ -18,7 +18,8 @@
 #   HA_VERSION_DEFAULT — default value for ha_version (e.g. "master")
 #
 # When triggered by `schedule`, these parameters are ignored and the defaults apply.
-# When called from publish-release.yml, ha_version is set explicitly (see that workflow).
+# When called from publish-release.yml, ha_version is set to the latest HA release tag (dynamically
+# resolved) for the stable job, and "dev" for the informational job.
 
 name: Test with Home Assistant
 

--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -1,7 +1,7 @@
 #
 #
 
-name: Linting (ruff, codespell)
+name: Check Lint (ruff, codespell)
 
 
 on:

--- a/.github/workflows/check-tag.yml
+++ b/.github/workflows/check-tag.yml
@@ -1,4 +1,7 @@
-name: Check tag
+#
+#
+
+name: Check Version Tag
 
 
 on:

--- a/.github/workflows/check-tag.yml
+++ b/.github/workflows/check-tag.yml
@@ -1,0 +1,43 @@
+name: Check tag
+
+
+on:
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+
+
+permissions:
+  contents: read
+
+
+jobs:
+  check-tag:
+    name: Validate tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check tag format
+        run: |
+          TAG="${{ inputs.tag_name }}"
+          if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "FAIL: tag '$TAG' does not match v[0-9]+.[0-9]+.[0-9]+"
+            exit 1
+          fi
+          echo "OK: tag format valid: $TAG"
+
+      - name: Check tag points to a commit on main
+        run: |
+          TAG="${{ inputs.tag_name }}"
+          git fetch origin main
+          TAGGED_COMMIT=$(git rev-parse "$TAG^{commit}")
+          if ! git merge-base --is-ancestor "$TAGGED_COMMIT" origin/main; then
+            echo "FAIL: '$TAG' does not point to a commit reachable from main"
+            exit 1
+          fi
+          echo "OK: '$TAG' is reachable from main"

--- a/.github/workflows/check-tests.yml
+++ b/.github/workflows/check-tests.yml
@@ -1,7 +1,7 @@
 #
 #
 
-name: Testing (pytest)
+name: Check Tests (pytest)
 
 
 on:

--- a/.github/workflows/check-type.yml
+++ b/.github/workflows/check-type.yml
@@ -1,7 +1,7 @@
 #
 #
 
-name: Typing (mypy)
+name: Check Typing (mypy)
 
 
 on:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -51,18 +51,17 @@ jobs:
           fi
           echo "OK: '$TAG' is reachable from main"
 
-  ha-integration-stable:
+  ha-integration-stable:  # Failures will block the release (in build's needs)
     name: HA Integration (stable)
     uses: ./.github/workflows/check-hass-tests.yml
     with:
-      ha_version: "master"  # HA's main development branch — must pass to release
+      ha_version: "master"
 
-  ha-integration-dev:
+  ha-integration-dev:  # Failures will not block the release (not in build's needs)
     name: HA Integration (dev)
     uses: ./.github/workflows/check-hass-tests.yml
     with:
-      ha_version: "dev"  # HA's dev branch — failures are informational only
-    # Not in build's needs — failures are informational and do not block the release
+      ha_version: "dev"
 
   build:
     name: Build distribution

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -55,13 +55,13 @@ jobs:
     name: HA Integration (stable)
     uses: ./.github/workflows/check-hass-tests.yml
     with:
-      ha_version: "master"
+      ha_version: "master"  # HA's main development branch — must pass to release
 
   ha-integration-dev:
     name: HA Integration (dev)
     uses: ./.github/workflows/check-hass-tests.yml
     with:
-      ha_version: "dev"
+      ha_version: "dev"  # HA's dev branch — failures are informational only
     # Not in build's needs — failures are informational and do not block the release
 
   build:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -11,21 +11,6 @@ permissions:
 
 
 jobs:
-  check-lint:
-    name: Linting
-    needs: [validate-tag]
-    uses: ./.github/workflows/check-lint.yml
-
-  check-type:
-    name: Typing
-    needs: [validate-tag]
-    uses: ./.github/workflows/check-type.yml
-
-  check-tests:
-    name: Testing
-    needs: [validate-tag]
-    uses: ./.github/workflows/check-tests.yml
-
   validate-tag:
     name: Validate release tag
     runs-on: ubuntu-latest
@@ -53,6 +38,21 @@ jobs:
             exit 1
           fi
           echo "OK: '$TAG' is reachable from main"
+
+  check-lint:
+    name: Linting
+    needs: [validate-tag]
+    uses: ./.github/workflows/check-lint.yml
+
+  check-type:
+    name: Typing
+    needs: [validate-tag]
+    uses: ./.github/workflows/check-type.yml
+
+  check-tests:
+    name: Testing
+    needs: [validate-tag]
+    uses: ./.github/workflows/check-tests.yml
 
   ha-integration-stable:  # Failures will block the release (in build's needs)
     name: HA Integration (stable)

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -13,14 +13,17 @@ permissions:
 jobs:
   check-lint:
     name: Linting
+    needs: [validate-tag]
     uses: ./.github/workflows/check-lint.yml
 
   check-type:
     name: Typing
+    needs: [validate-tag]
     uses: ./.github/workflows/check-type.yml
 
   check-tests:
     name: Testing
+    needs: [validate-tag]
     uses: ./.github/workflows/check-tests.yml
 
   validate-tag:
@@ -53,19 +56,22 @@ jobs:
 
   ha-integration-stable:  # Failures will block the release (in build's needs)
     name: HA Integration (stable)
+    needs: [check-lint, check-type, check-tests]
     uses: ./.github/workflows/check-hass-tests.yml
     with:
       ha_version: "master"
 
-  ha-integration-dev:  # Failures will not block the release (not in build's needs)
+  ha-integration-dev:  # Failures should not block the release (not in build's needs)
     name: HA Integration (dev)
+    needs: [check-lint, check-type, check-tests]
     uses: ./.github/workflows/check-hass-tests.yml
     with:
       ha_version: "dev"
+    continue-on-error: true
 
   build:
     name: Build distribution
-    needs: [validate-tag, check-lint, check-type, check-tests, ha-integration-stable]
+    needs: [ha-integration-stable]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,3 +1,6 @@
+#
+#
+
 name: Publish to PyPI
 
 
@@ -22,15 +25,15 @@ jobs:
     needs: [validate-tag]
     uses: ./.github/workflows/check-lint.yml
 
-  check-type:
-    name: Typing
-    needs: [validate-tag]
-    uses: ./.github/workflows/check-type.yml
-
   check-tests:
     name: Testing
     needs: [validate-tag]
     uses: ./.github/workflows/check-tests.yml
+
+  check-type:
+    name: Typing
+    needs: [validate-tag]
+    uses: ./.github/workflows/check-type.yml
 
   ha-integration-stable:  # Failures will block the release (in build's needs)
     name: HA Integration (latest release)

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -32,28 +32,10 @@ jobs:
     needs: [validate-tag]
     uses: ./.github/workflows/check-tests.yml
 
-  get-ha-latest-release:
-    name: Get latest HA release tag
-    needs: [validate-tag]
-    runs-on: ubuntu-latest
-    outputs:
-      ha_version: ${{ steps.get-release.outputs.ha_version }}
-    steps:
-      - name: Fetch latest HA release tag (including pre-releases)
-        id: get-release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          HA_VERSION=$(gh api repos/home-assistant/core/releases --jq '.[0].tag_name')
-          echo "ha_version=${HA_VERSION}" >> $GITHUB_OUTPUT
-          echo "Latest HA release: ${HA_VERSION}"
-
   ha-integration-stable:  # Failures will block the release (in build's needs)
-    name: HA Integration (${{ needs.get-ha-latest-release.outputs.ha_version }})
-    needs: [check-lint, check-type, check-tests, get-ha-latest-release]
+    name: HA Integration (latest release)
+    needs: [check-lint, check-type, check-tests]
     uses: ./.github/workflows/check-hass-tests.yml
-    with:
-      ha_version: ${{ needs.get-ha-latest-release.outputs.ha_version }}
 
   ha-integration-dev:  # Failures should not block the release (not in build's needs)
     name: HA Integration (dev)

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -11,7 +11,7 @@ permissions:
 
 
 jobs:
-  validate-tag:
+  validate-tag:  # Don't go any further, if there is no valid tag
     name: Validate release tag
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -13,31 +13,9 @@ permissions:
 jobs:
   validate-tag:  # Don't go any further, if there is no valid tag
     name: Validate release tag
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Check tag format
-        run: |
-          TAG="${{ github.event.release.tag_name }}"
-          if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "FAIL: tag '$TAG' does not match v[0-9]+.[0-9]+.[0-9]+"
-            exit 1
-          fi
-          echo "OK: tag format valid: $TAG"
-
-      - name: Check tag points to a commit on main
-        run: |
-          TAG="${{ github.event.release.tag_name }}"
-          git fetch origin main
-          TAGGED_COMMIT=$(git rev-parse "$TAG^{commit}")
-          if ! git merge-base --is-ancestor "$TAGGED_COMMIT" origin/main; then
-            echo "FAIL: '$TAG' does not point to a commit reachable from main"
-            exit 1
-          fi
-          echo "OK: '$TAG' is reachable from main"
+    uses: ./.github/workflows/check-tag.yml
+    with:
+      tag_name: ${{ github.event.release.tag_name }}
 
   check-lint:
     name: Linting
@@ -54,12 +32,28 @@ jobs:
     needs: [validate-tag]
     uses: ./.github/workflows/check-tests.yml
 
+  get-ha-latest-release:
+    name: Get latest HA release tag
+    needs: [validate-tag]
+    runs-on: ubuntu-latest
+    outputs:
+      ha_version: ${{ steps.get-release.outputs.ha_version }}
+    steps:
+      - name: Fetch latest HA release tag (including pre-releases)
+        id: get-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          HA_VERSION=$(gh api repos/home-assistant/core/releases --jq '.[0].tag_name')
+          echo "ha_version=${HA_VERSION}" >> $GITHUB_OUTPUT
+          echo "Latest HA release: ${HA_VERSION}"
+
   ha-integration-stable:  # Failures will block the release (in build's needs)
-    name: HA Integration (stable)
-    needs: [check-lint, check-type, check-tests]
+    name: HA Integration (${{ needs.get-ha-latest-release.outputs.ha_version }})
+    needs: [check-lint, check-type, check-tests, get-ha-latest-release]
     uses: ./.github/workflows/check-hass-tests.yml
     with:
-      ha_version: "master"
+      ha_version: ${{ needs.get-ha-latest-release.outputs.ha_version }}
 
   ha-integration-dev:  # Failures should not block the release (not in build's needs)
     name: HA Integration (dev)

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,3 +1,6 @@
+#
+#
+
 name: Release Drafter
 
 

--- a/.github/workflows/validate-tag.yml
+++ b/.github/workflows/validate-tag.yml
@@ -1,4 +1,4 @@
-name: Tag
+name: Validate Version Tag
 
 
 on:
@@ -24,15 +24,15 @@ jobs:
     needs: [validate-tag]
     uses: ./.github/workflows/check-lint.yml
 
-  check-type:
-    name: Typing
-    needs: [validate-tag]
-    uses: ./.github/workflows/check-type.yml
-
   check-tests:
     name: Testing
     needs: [validate-tag]
     uses: ./.github/workflows/check-tests.yml
+
+  check-type:
+    name: Typing
+    needs: [validate-tag]
+    uses: ./.github/workflows/check-type.yml
 
   ha-integration-stable:
     name: HA Integration (stable)

--- a/.github/workflows/validate-tag.yml
+++ b/.github/workflows/validate-tag.yml
@@ -5,6 +5,7 @@ on:
   push:
     tags:
       - "v[0-9]*.[0-9]*.[0-9]*"
+      - "[0-9]*.[0-9]*.[0-9]*"  # invalid, trigger on these to provide feedback
 
 
 permissions:

--- a/.github/workflows/validate-tag.yml
+++ b/.github/workflows/validate-tag.yml
@@ -10,41 +10,32 @@ on:
 permissions:
   contents: read
 
-  
+
 jobs:
+  validate-tag:  # Don't go any further, if there is no valid tag
+    name: Validate tag
+    uses: ./.github/workflows/check-tag.yml
+    with:
+      tag_name: ${{ github.ref_name }}
+
   check-lint:
     name: Linting
+    needs: [validate-tag]
     uses: ./.github/workflows/check-lint.yml
 
   check-type:
     name: Typing
+    needs: [validate-tag]
     uses: ./.github/workflows/check-type.yml
 
   check-tests:
     name: Testing
+    needs: [validate-tag]
     uses: ./.github/workflows/check-tests.yml
 
-  ha-integration:
+  ha-integration-stable:
     name: HA Integration (stable)
+    needs: [check-lint, check-type, check-tests]
     uses: ./.github/workflows/check-hass-tests.yml
     with:
       ha_version: "master"
-
-  validate-tag:
-    name: Validate tag
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Check tag points to a commit on main
-        run: |
-          TAG="${GITHUB_REF#refs/tags/}"
-          git fetch origin main
-          TAGGED_COMMIT=$(git rev-parse "$TAG^{commit}")
-          if ! git merge-base --is-ancestor "$TAGGED_COMMIT" origin/main; then
-            echo "FAIL: '$TAG' does not point to a commit reachable from main"
-            exit 1
-          fi
-          echo "OK: '$TAG' is reachable from main"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -82,6 +82,7 @@
         "tccna",
         "tcss",
         "testpaths",
+        "vars",
         "venv",
         "websession",
         "Wifi"


### PR DESCRIPTION
Makes the `ha_repo` and `ha_version` parameters visible without having to read the YAML closely.

### Changes

**`check-hass-tests.yml`**
- Expanded the top-of-file comment block to document both parameters: purpose, default, and common example values (including fork usage and specific release tags)
- Both job names now embed the parameters — e.g. `Test with home-assistant/core@master (Python 3.13.x)` — so they're visible directly in the GitHub Actions UI

**`publish-release.yml`**
- Added inline comments on the hardcoded `ha_version` values (`"master"` = must pass to release; `"dev"` = informational only) so the intent is clear without tracing back to the called workflow