### PR TITLE
ci: remove continue-on-error from ha-integration-dev

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -46,7 +46,6 @@ jobs:
     uses: ./.github/workflows/check-hass-tests.yml
     with:
       ha_version: "dev"
-    continue-on-error: true
 
   build:
     name: Build distribution


### PR DESCRIPTION
## Summary

- `ha-integration-dev` is not in `build`'s `needs`, so its failures already don't block the release pipeline
- Removing `continue-on-error: true` lets the job surface its true status in the GitHub Actions UI instead of always showing green

🤖 Generated with [Claude Code](https://claude.com/claude-code)