### PR TITLE
fix: build sdist and wheel independently from git checkout

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -69,7 +69,9 @@ jobs:
         run: uv pip install --system build
 
       - name: Build package
-        run: python -m build
+        run: |
+          python -m build --sdist
+          python -m build --wheel
 
       - uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
## Summary

- `python -m build` (no flags) builds the wheel *from the sdist*, not from source
- `hatch-vcs` writes `_version.py` to `src/_evohome/_version.py`, but the sdist strips the `src/` prefix (`sources = ["src"]`), so that directory does not exist in the extracted sdist
- The wheel build fails with `FileNotFoundError` on the write

Building each format with an explicit flag (`--sdist`, `--wheel`) builds both directly from the git checkout, where `src/` exists and `hatch-vcs` can resolve the version from the tag.

Fixes the publish failure seen in https://github.com/zxdavb/evohome-async/actions/runs/26389285047/job/77675110438

## Test plan

- [ ] Verify `python -m build --sdist` and `python -m build --wheel` both succeed locally (confirmed)
- [ ] Re-publish the release to trigger `publish-release.yml` and confirm the build step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)