### PR TITLE
fix: use hatch build to avoid wheel-via-sdist failure

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -69,7 +69,9 @@ jobs:
         run: uv pip install --system build
 
       - name: Build package
-        run: python -m build
+        run: |
+          python -m build --sdist
+          python -m build --wheel
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -65,13 +65,11 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
 
-      - name: Install build dependencies
-        run: uv pip install --system build
+      - name: Install hatch
+        run: uv pip install --system hatch
 
       - name: Build package
-        run: |
-          python -m build --sdist
-          python -m build --wheel
+        run: hatch build
 
       - uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
## Summary

`python -m build --wheel` in build 1.x **unconditionally** calls `build_package_via_sdist`. The wheel is always built from an extracted sdist, never directly from source. The extracted sdist lacks `src/` (stripped by `sources = ["src"]`), so the `hatch-vcs` hook cannot write `_version.py` to `src/_evohome/_version.py`.

`hatch build` builds the wheel directly from the source tree — no sdist intermediate, no path mismatch.

Verified locally: both sdist and wheel build successfully with `hatch build`.

## Test plan

- [x] `hatch build` succeeds locally (sdist + wheel)
- [ ] Merge, then re-publish the v1.3.1 release to trigger `publish-release.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)