### PR TITLE
Exclude markdown from ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,7 @@ show_missing = true
 ## ruff ##############################################################################
 
 [tool.ruff]
-exclude = ["docs/*.py", "tests/tests_cc"]
+exclude = ["docs/*.py", "tests/tests_cc", "*.md"]  # ruff >= 0.16 formats code blocks in markdown
 src = ["src", "tests"]
 target-version = "py313"  # the *minimum* supported runtime (we dev/test on 3.14, run on 3.13)
 required-version = ">=0.15.16"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ cli = [
 dev = [
   # linting
   "prek>=0.4.10",
-  "ruff>=0.15.22",
+  "ruff>=0.16",
   # typing
   "mypy>=2.3.0",
   "types-aiofiles>=25.1.0.20260518",
@@ -138,7 +138,7 @@ show_missing = true
 exclude = ["docs/*.py", "tests/tests_cc", "*.md"]  # ruff >= 0.16 formats code blocks in markdown
 src = ["src", "tests"]
 target-version = "py313"  # the *minimum* supported runtime (we dev/test on 3.14, run on 3.13)
-required-version = ">=0.15.16"
+required-version = ">=0.16"  # PLR0917 (and markdown formatting) arrived in 0.16
 
 [tool.ruff.lint]
 select = [

--- a/tests/tests/test_v0_auth.py
+++ b/tests/tests/test_v0_auth.py
@@ -116,7 +116,7 @@ async def test_get_session_id(
     assert session_manager.is_session_valid() is False
 
 
-async def test_session_manager(
+async def test_session_manager(  # noqa: PLR0917  # pytest injects fixtures by keyword
     cache_data_expired: CacheDataT,
     cache_data_valid: CacheDataT,
     cache_path: Path,

--- a/tests/tests/test_v2_auth.py
+++ b/tests/tests/test_v2_auth.py
@@ -123,7 +123,7 @@ async def test_get_auth_token(
     assert token_manager.is_token_valid() is False
 
 
-async def test_token_manager(
+async def test_token_manager(  # noqa: PLR0917  # pytest injects fixtures by keyword
     cache_data_expired: CacheDataT,
     cache_data_valid: CacheDataT,
     cache_path: Path,


### PR DESCRIPTION
## Why

CI installs ruff unpinned, and **ruff 0.16.0** brought two changes that fail `main` and every open PR (e.g. #103, which is only a Dependabot actions bump):

1. `ruff format` now formats Python code blocks embedded in Markdown → `CONTRIBUTING.md` would be reformatted.
2. `PLR0917` (too-many-positional-arguments) left preview → fails on two auth tests with >5 fixtures.

## What

- Adds `*.md` to `[tool.ruff] exclude` — docs shouldn't be held to the code formatter.
- `# noqa: PLR0917` on `test_session_manager` / `test_token_manager`. pytest injects fixtures by keyword, so the rule doesn't apply to these; scoped to the two definitions rather than disabling `PLR0917` repo-wide.
- Raises the ruff floor to `>=0.16` (`required-version` and the `dev` extra). Not a pin — we still track latest. Needed because those `noqa` directives are `RUF100` (unused) on ruff < 0.16, so the floor keeps local checks in step with CI.

**Note:** contributors on ruff 0.15.x will need `uv sync --upgrade-package ruff`; until then ruff exits with `Required version >=0.16 does not match the running version`.

## Verification

| | ruff 0.15.16 | ruff 0.16.0 |
|---|---|---|
| `ruff check .` | refuses to run (below `required-version`) | pass |
| `ruff format --check .` | refuses to run | 77 files, pass |

Pre-commit hooks (ruff check, ruff format, mypy) pass with ruff 0.16.0 in the venv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)