### PR TITLE
Remove dependabot.yml — version updates are Renovate's job

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,0 @@
-# Version updates disabled — managed by Renovate instead.
-# Security alerts from Dependabot remain active regardless of this file.
-
-version: 2
-updates: []


### PR DESCRIPTION
## Why

`.github/dependabot.yml` has held `updates: []` since 2026-05-20, with a comment saying version updates were disabled. That is not a valid Dependabot config, so it never took effect — Dependabot kept running the last config that parsed (`6071fce`, Jan 2026).

The fingerprint is unambiguous: that old config defines a `github-actions` group named **`actions`** on `.github/workflows`, and #103's branch is `dependabot/github_actions/dot-github/workflows/actions-f435755103`.

Since the empty file landed, Dependabot has opened 7 more PRs — #65, #86, #90, #96, #101, #102, #103 — several duplicating Renovate's work (#103 vs #105, both bumping `astral-sh/setup-uv` to v9).

## What

Deletes the file. That is the supported off-switch for version updates; Renovate ([renovate.json](../blob/main/renovate.json)) already covers both `github-actions` and Python deps.

## Not affected by this PR

Repo-level security settings, set separately (they don't depend on `dependabot.yml`):

| Setting | Status |
|---|---|
| Dependabot alerts | **enabled** (was off) |
| Dependabot security updates | **enabled** (was off) |
| Secret scanning + push protection | enabled, unchanged |

🤖 Generated with [Claude Code](https://claude.com/claude-code)