### PR TITLE
Align runtime dep floors with HA's pins, and keep them there

### DIFF
--- a/.github/scripts/check-hass-pins.py
+++ b/.github/scripts/check-hass-pins.py
@@ -1,0 +1,151 @@
+"""Check this library's runtime dependency floors against Home Assistant's pins.
+
+HA pins its core dependencies exactly (e.g. `aiohttp==3.14.3`), so our floors
+must equal those pins:
+
+  - a floor *below* HA's pin claims support for versions we never test against;
+  - a floor *above* what HA stable pins makes the library uninstallable there,
+    as HA's `==` pin can no longer satisfy it.
+
+So the floors track HA stable (the `master` branch, which is the latest release);
+`dev` is read only to give advance warning of a bump that is coming.
+
+Only the deps in TRACKED are checked — dev/test deps are Renovate's business.
+Exits non-zero if a floor no longer matches HA stable's pin.
+"""
+
+import logging
+import os
+import re
+import tomllib
+import urllib.request
+from pathlib import Path
+
+# runtime deps that must track HA's pins; see [project.dependencies]
+TRACKED = ("aiohttp", "aiozoneinfo", "voluptuous")
+
+STABLE = "master"  # HA cuts releases from master; dev is the next release
+DEV = "dev"
+
+CONSTRAINTS = "homeassistant/package_constraints.txt"  # flat `name==version` lines
+CONST_PY = "homeassistant/const.py"
+
+ROOT = Path(
+    __file__
+).parent.parent.parent  # repo root (.github/scripts/ -> .github/ -> root)
+
+_LOGGER = logging.getLogger(Path(__file__).stem)
+
+
+class HassPinMismatchError(Exception):
+    """A runtime dependency floor no longer matches Home Assistant's pin."""
+
+
+def normalise(name: str) -> str:
+    """Return a PEP 503 normalised distribution name."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def fetch(ref: str, path: str) -> str:
+    """Return a file from home-assistant/core (raises: the check must fail loudly)."""
+    with urllib.request.urlopen(
+        f"https://raw.githubusercontent.com/home-assistant/core/{ref}/{path}",
+        timeout=10,
+    ) as rsp:
+        body: bytes = rsp.read()
+    return body.decode()
+
+
+def parse_pins(text: str) -> dict[str, str]:
+    """Return the `name==version` pins of a constraints file, keyed by name."""
+    matches = (re.match(r"([\w.-]+)==([^\s;#]+)", line) for line in text.splitlines())
+    return {normalise(m[1]): m[2] for m in matches if m}
+
+
+def parse_floors() -> dict[str, str]:
+    """Return the `name>=version` floors of [project.dependencies], keyed by name."""
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text())
+    matches = (
+        re.fullmatch(r"([\w.-]+)>=([^\s,;]+)", spec)
+        for spec in pyproject["project"]["dependencies"]
+    )
+    return {normalise(m[1]): m[2] for m in matches if m}
+
+
+def version_key(version: str) -> tuple[int, ...]:
+    """Return an orderable key for a version string (numeric segments only)."""
+    return tuple(int(segment) for segment in re.findall(r"\d+", version))
+
+
+def ha_version() -> str:
+    """Return HA stable's version, e.g. '2026.7.4' (best-effort: it is cosmetic)."""
+    try:
+        const = fetch(STABLE, CONST_PY)
+    except (OSError, ValueError):
+        return "unknown"
+
+    parts = [
+        re.search(rf'^{part}_VERSION: Final = "?([\w.]+)"?', const, re.MULTILINE)
+        for part in ("MAJOR", "MINOR", "PATCH")
+    ]
+    return ".".join(m[1] for m in parts if m) if all(parts) else "unknown"
+
+
+def write_summary(lines: list[str]) -> None:
+    """Append lines to the GitHub Actions step summary, when running in CI."""
+    if summary := os.environ.get("GITHUB_STEP_SUMMARY"):
+        with Path(summary).open("a") as f:
+            f.write("\n".join(lines) + "\n")
+
+
+def main() -> None:
+    """Compare our floors with HA's pins; raise if they have drifted."""
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    floors = parse_floors()
+    stable = parse_pins(fetch(STABLE, CONSTRAINTS))
+    dev = parse_pins(fetch(DEV, CONSTRAINTS))
+
+    version = ha_version()
+    _LOGGER.info("Comparing [project.dependencies] with HA %s (%s)", version, STABLE)
+
+    mismatches: list[str] = []
+    warnings: list[str] = []
+
+    for name in map(normalise, TRACKED):
+        floor, pin = floors.get(name), stable.get(name)
+
+        if floor is None:
+            mismatches.append(f"`{name}`: no `>=` floor in [project.dependencies]")
+            continue
+        if pin is None:
+            mismatches.append(f"`{name}`: not pinned by HA — still a core dep?")
+            continue
+
+        if floor != pin:
+            mismatches.append(f"`{name}`: floor `>={floor}` != HA's `=={pin}`")
+        else:
+            _LOGGER.info("%s: >=%s matches HA's pin", name, floor)
+
+        if (ahead := dev.get(name)) and version_key(ahead) > version_key(pin):
+            warnings.append(f"`{name}`: HA dev is on `=={ahead}` (stable `=={pin}`)")
+
+    for warning in warnings:
+        _LOGGER.warning("A bump is coming — %s", warning)
+
+    write_summary(
+        [f"### Runtime deps vs Home Assistant {version}", ""]
+        + [f"- ❌ {line}" for line in mismatches]
+        + [f"- ⚠️ {line} — a bump is coming" for line in warnings]
+        + ([] if mismatches else ["- ✅ all tracked floors match HA stable"])
+    )
+
+    if mismatches:
+        raise HassPinMismatchError(
+            f"Runtime dependency floors have drifted from HA {version}: "
+            + "; ".join(mismatches)
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/check-hass-tests.yml
+++ b/.github/workflows/check-hass-tests.yml
@@ -18,6 +18,10 @@
 #
 # workflow_dispatch lets you override the target for ad-hoc runs (see inputs below), e.g. point at
 # a release branch/tag ("2026.7", "v2026.7.2") or a fork before a large HA change.
+#
+# It also carries check-hass-pins, an independent job asserting that our runtime dependency floors
+# still equal HA's exact pins. That job ignores the target above and always reads HA stable, as the
+# floors are a contract with *released* HA (see .github/scripts/check-hass-pins.py).
 
 name: Test with Home Assistant
 
@@ -26,6 +30,7 @@ on:
   pull_request:
     branches: [ "main" ]
     paths: [
+      ".github/scripts/check-hass-pins.py",
       ".github/workflows/check-hass-tests.yml",
       "pyproject.toml",
       "src/**.py",
@@ -34,6 +39,7 @@ on:
   push:
     branches: [ "dev" ]
     paths: [
+      ".github/scripts/check-hass-pins.py",
       ".github/workflows/check-hass-tests.yml",
       "pyproject.toml",
       "src/**.py",
@@ -74,6 +80,23 @@ permissions:
 
 
 jobs:
+  check-hass-pins:
+    name: Check runtime deps match HA's pins
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+          check-latest: true
+
+      # Always compares against HA stable (master) + dev, regardless of the test
+      # target above: the floors are a contract with released HA, not with a branch.
+      - name: Compare [project.dependencies] with HA's package_constraints.txt
+        run: python3 .github/scripts/check-hass-pins.py
+
   get-python-version:
     name: Get Python version from HA
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,10 @@ readme = "README.md"
 authors = [{ name = "David Bonnes", email = "zxdavb@bonnes.me" }]
 maintainers = [{ name = "David Bonnes", email = "zxdavb@bonnes.me" }]
 dependencies = [
-  "aiohttp>=3.13.5",
+  "aiohttp>=3.14.3",
   "aiozoneinfo>=0.2.3",
   "voluptuous>=0.15.2",
-]  # must support Home Assistant
+]  # floors must equal HA's pins; see .github/scripts/check-hass-pins.py
 requires-python = ">=3.13"  # also see: 'python_version', below
 license = "Apache-2.0"
 


### PR DESCRIPTION
## Why

HA pins its core dependencies exactly (`aiohttp==3.14.3`), which makes the two directions of drift asymmetric:

- A floor **below** HA's pin declares support for versions we never test against. A non-HA user on the older version runs an untested combination.
- A floor **above** what HA **stable** pins is unresolvable — HA literally cannot install the library, and their CI rejects the bump.

`aiohttp` had drifted into the first case: `>=3.13.5` against HA's `==3.14.3`.

## What

**1. Bumps `aiohttp` to `>=3.14.3`** — matching HA 2026.7.4 and `dev`. `aiozoneinfo` and `voluptuous` were already aligned.

**2. Adds [`.github/scripts/check-hass-pins.py`](.github/scripts/check-hass-pins.py)** — stdlib only, following the existing `get-python-versions.py` pattern. It reads `[project.dependencies]` with `tomllib`, fetches HA's `homeassistant/package_constraints.txt` (flat `name==version`, the file HA installs with), and:

| Condition | Result |
|---|---|
| floor ≠ HA stable pin | ❌ fails the job |
| HA `dev` pin > stable pin | ⚠️ warning — a bump is coming, no action yet |
| floor = pin, dev level | ✅ pass |

It compares against **HA stable, not `dev`** — deliberately. HA bumps deps mid-cycle, so a `dev`-derived floor could ship a library that's uninstallable on HA stable. HA cuts releases from `master`, so `master` is read as stable; no API token or rate limit involved. Results also go to the job's step summary.

Only `aiohttp`, `aiozoneinfo` and `voluptuous` are tracked (`TRACKED` in the script) — dev/test deps stay Renovate's business.

**3. Runs as its own job in `check-hass-tests.yml`**, which already triggers on `pyproject.toml` changes, PRs into `main` and weekly. It ignores that workflow's HA target inputs, since the floors are a contract with released HA rather than with a branch.

## Verification

- Against `main` before the bump: fails with ``aiohttp`: floor `>=3.13.5` != HA's `==3.14.3``, exit 1.
- After the bump: all three match, exit 0.
- Dev-ahead path exercised with a stubbed fetch (dev on `3.15.0`, stable on `3.14.3`) → warning, still exit 0.
- `ruff check`, `ruff format --check`, `mypy` (strict) all clean — no suppressions.

## Note on branch protection

This is a single non-matrix job, so `check-hass-pins` is a stable check name — add it directly to branch protection to make it blocking. It's deliberately **not** routed through the `hass-ok` sentinel, which carries `continue-on-error: true` and would neuter it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)