### PR TITLE
ci: HA test failures should warn, not block

### DIFF
--- a/.github/workflows/check-hass-tests.yml
+++ b/.github/workflows/check-hass-tests.yml
@@ -232,6 +232,8 @@ jobs:
           python -c "import evohomeasync2; assert 'evohome-async' in evohomeasync2.__file__, 'Not using local evohome-async!'"
 
       - name: Run Home Assistant evohome tests (only)
+        id: hass-tests
+        continue-on-error: true  # a breaking change fails here until HA is updated: warn, don't block
         working-directory: home-assistant-core
         env:
           PYTHONDONTWRITEBYTECODE: 1  # cspell:ignore PYTHONDONTWRITEBYTECODE
@@ -252,13 +254,20 @@ jobs:
             --cov-report term-missing \
             tests/components/evohome/
 
+      - name: Warn if the HA tests failed
+        if: steps.hass-tests.outcome == 'failure'
+        run: |
+          echo "::warning title=HA evohome tests failed::The evohome integration in \
+          ${{ env.HA_REPO }}@${{ env.HA_VERSION }} does not pass against this commit. \
+          If this is a deliberate breaking change, a companion PR to home-assistant/core \
+          is needed; otherwise, this is a regression. See the job log for the failures."
+
       - run: echo "🍏 This job's status is ${{ job.status }}."
 
   hass-ok:  # stable sentinel job for branch protection rules (avoids listing matrix variants)
     needs: test-with-hass
     runs-on: ubuntu-latest
     if: always()
-    continue-on-error: true  # informational for now — failures do not block merges
     steps:
       - name: All HA checks passed
         run: |


### PR DESCRIPTION
The `Test with home-assistant/core@dev` job is a hard gate, which creates a
circularity for any deliberate breaking change:

- the library change cannot merge, because HA's tests fail against it
- the companion HA PR cannot be written, because it needs the library change to exist

Live example: #116 renames a TypedDict that HA imports, and is otherwise green — every
other check passes, but that one job blocks it.

## Change

- the pytest step gets `continue-on-error: true`, so a test failure no longer fails the job
- a new step emits a `::warning::` when it does, naming both possibilities — an expected
  breaking change needing a companion HA PR, or a regression. It shows on the run summary
  and on the PR, so the signal is not lost
- `hass-ok` loses its own `continue-on-error`. With the above it is a meaningful sentinel
  again: it now fails only if the job itself broke (checkout, install, compile), not on
  test results — which makes it suitable as a required check once branch protection is on

## Note

This deliberately weakens a gate that #78 strengthened. The distinction is that #78 was
about not ignoring *regressions*, which the warning still surfaces; this is about not
having an unresolvable ordering dependency between two repos.