### PR TITLE
Revert "ci: HA test failures should warn, not block"

### DIFF
--- a/.github/workflows/check-hass-tests.yml
+++ b/.github/workflows/check-hass-tests.yml
@@ -232,8 +232,6 @@ jobs:
           python -c "import evohomeasync2; assert 'evohome-async' in evohomeasync2.__file__, 'Not using local evohome-async!'"
 
       - name: Run Home Assistant evohome tests (only)
-        id: hass-tests
-        continue-on-error: true  # a breaking change fails here until HA is updated: warn, don't block
         working-directory: home-assistant-core
         env:
           PYTHONDONTWRITEBYTECODE: 1  # cspell:ignore PYTHONDONTWRITEBYTECODE
@@ -254,20 +252,13 @@ jobs:
             --cov-report term-missing \
             tests/components/evohome/
 
-      - name: Warn if the HA tests failed
-        if: steps.hass-tests.outcome == 'failure'
-        run: |
-          echo "::warning title=HA evohome tests failed::The evohome integration in \
-          ${{ env.HA_REPO }}@${{ env.HA_VERSION }} does not pass against this commit. \
-          If this is a deliberate breaking change, a companion PR to home-assistant/core \
-          is needed; otherwise, this is a regression. See the job log for the failures."
-
       - run: echo "🍏 This job's status is ${{ job.status }}."
 
   hass-ok:  # stable sentinel job for branch protection rules (avoids listing matrix variants)
     needs: test-with-hass
     runs-on: ubuntu-latest
     if: always()
+    continue-on-error: true  # informational for now — failures do not block merges
     steps:
       - name: All HA checks passed
         run: |


### PR DESCRIPTION
Reverts #117, which was a mistake.

## Why

**The problem it solved did not exist.** `main` has no branch protection, so a failing
check has never blocked a merge — GitHub flags "some checks were not successful" and
turns the merge button yellow, but the merge is still available. #116 was mergeable
the whole time; I misdiagnosed a visible failure as a blocking one.

**And the cure was worse.** With `continue-on-error` on the pytest step, the job reports
**success** while its tests fail — demoting a hard red X to a `::warning::` annotation
that is easy to miss. That is precisely what happened on the next breaking change pushed
to #116: the HA tests failed as expected, and it barely surfaced.

## What the original design already did right

- `test-with-hass` fails **red and visible** when HA's tests break
- `hass-ok` — the sentinel — keeps `continue-on-error: true`, so once branch protection
  is enabled it can be a *required* check without HA test failures blocking merges

That decoupling belongs in the sentinel, not in the job doing the work. Reverting
restores it.