### PR TITLE
docs: add branch model section; expand RELEASING merge strategy

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -12,6 +12,30 @@ ci/my-change            ↗
 - **`main`** only receives merges from `dev` (or direct non-development PRs) — never individual feature branches.
 - Tags are always created on `main`.
 
+### Merge strategy
+
+| Merge | Method | Why |
+| --- | --- | --- |
+| feature → `dev` | **squash** | one commit per PR; keeps `dev` readable |
+| `dev` → `main` | **merge commit — never squash** | see below |
+| direct → `main` (Renovate, CI) | squash | single-purpose branches |
+
+Squashing `dev` → `main` would put a commit on `main` that is not in `dev`, so the branches diverge
+and `dev` has to be force-reset after every release. A merge commit keeps `dev` an ancestor of
+`main`, so no reset is ever needed and both branches can stay fully protected.
+
+### Branch protection
+
+Both branches require a PR and green `lint-ok`, `test-ok` and `type-ok` checks; neither can be
+force-pushed or deleted. `main` additionally requires branches to be up to date before merging.
+
+`hass-ok` is deliberately **not** a required check: `check-hass-tests.yml` is path-filtered, so it
+does not run on every PR, and requiring it would leave doc-only PRs waiting for a status that never
+arrives. It also carries `continue-on-error`, so HA failures stay red and visible without blocking
+a merge.
+
+See [Prerequisites](#prerequisites-one-time-setup) for the configuration itself.
+
 ---
 
 ## Day-to-day development
@@ -77,22 +101,28 @@ Publishing triggers **`publish-release.yml`**, which:
 - builds the wheel (`python -m build`),
 - publishes to PyPI via OIDC Trusted Publisher (no stored tokens required).
 
-### 4. Reset `dev`
+### 4. Sync `dev` with `main`
 
-After the release is published, fast-forward `dev` to `main` so the next development cycle starts clean:
+`main` moves ahead of `dev` whenever anything lands on it directly — the release merge commit
+itself, and every Renovate or CI PR in between. Those commits do not reach `dev` on their own:
 
 ```bash
 git checkout dev && git pull
-git merge --ff-only main
+git merge --ff-only main    # after a release, when dev has no commits of its own
 git push origin dev
 ```
 
-Alternatively, delete and recreate:
+If `dev` already has work in flight, the fast-forward is refused; use a plain `git merge main`
+instead, which makes a merge commit on `dev`. That is expected and allowed.
 
-```bash
-git push origin --delete dev
-git push origin main:dev
-```
+Mid-cycle syncing is usually unnecessary — the only cost of lagging is that feature branches run CI
+against slightly older pins, and the next `dev` → `main` merge resolves it. Sync when a Renovate
+change actually matters to work in progress, and after each release.
+
+> **Note:** this step only works because `dev` → `main` uses a **merge commit** (see
+> [Merge strategy](#merge-strategy)). If that merge is ever squashed, `dev` keeps commits `main`
+> never received, `--ff-only` is refused permanently, and the only way back is to delete and
+> recreate `dev` — which branch protection forbids.
 
 ---
 
@@ -103,4 +133,38 @@ git push origin main:dev
   - Workflow: `publish-release.yml`
   - Environment: `pypi`
 - **GitHub environment `pypi`** must exist in repo Settings → Environments.
-- **GitHub Ruleset "Version tag protection"** enforces that `lint-ok`, `test-ok`, and `type-ok` status checks pass before a version tag can be pushed. This is in addition to the CI ancestry check in `validate-tag.yml`.
+- **GitHub Rulesets** (Settings → Rules → Rulesets) carry all branch and tag protection. Use
+  rulesets, **not** the older "branch protection rules" — the two systems stack, and where they
+  disagree the most restrictive wins, which makes the effective state hard to reason about.
+  Inspect what is actually in force with:
+
+  ```bash
+  gh api repos/zxdavb/evohome-async/rules/branches/main   # and .../dev
+  gh api repos/zxdavb/evohome-async/rulesets
+  ```
+
+  Note the classic endpoint `repos/.../branches/main/protection` returns *"Branch not protected"*
+  even when a ruleset is protecting the branch — it is blind to rulesets, and has misled an audit
+  of this repo before.
+
+  Three rulesets are expected:
+
+  | Ruleset | Target | Rules |
+  | --- | --- | --- |
+  | Protect main branch | `~DEFAULT_BRANCH` | deletion, non-fast-forward, pull request (0 approvals), required status checks (`lint-ok`, `test-ok`, `type-ok`, strict) |
+  | Protect dev branch | `refs/heads/dev` | as above, minus strict; plus a repository-admin bypass for emergencies |
+  | Version tag protection | `refs/tags/v*` | required status checks (`lint-ok`, `test-ok`, `type-ok`) before a version tag can be pushed — in addition to the CI ancestry check in `validate-tag.yml` |
+
+  ⚠️ **Quote branch names carefully when creating a ruleset.** A condition of `refs/heads/"dev"`
+  (with literal quotes) matches no branch at all and silently protects nothing.
+
+  **The merge strategy cannot be fully enforced.** A ruleset's `allowed_merge_methods` applies to
+  every PR into the branch and cannot be conditioned on the source branch — and `main` legitimately
+  needs both methods: a merge commit for `dev` → `main`, and squash for the Renovate/CI PRs that
+  target it directly (Renovate automerges with `automergeStrategy: "squash"`). Restricting `main`
+  to `["merge"]` would block every Renovate PR. So `main` allows `["merge", "squash"]` — `rebase`
+  is dropped as unused — and "never squash `dev` → `main`" remains a discipline rule.
+
+  `dev` is different: everything entering it is a feature PR, so it is set to `["squash"]`, which
+  does enforce the rule. The one consequence is that a `main` → `dev` back-merge cannot be done as
+  a PR; do that sync by direct push, as [step 4](#4-sync-dev-with-main) describes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,11 +23,11 @@ Before opening a PR, **every one** of these commands must pass cleanly:
 ```bash
 ruff check .               # linting — zero warnings
 ruff format --check .      # formatting
-mypy                       # strict type checking
+mypy --strict              # strict type checking
 pytest                     # full test suite
 ```
 
-The cleanest way to do this is to install pre-commit checks - or manually - via prek:
+You should also install the pre-commit checks - or run them manually - via prek:
 
 ```bash
 prek run --all             # run pre-commit tests
@@ -170,6 +170,28 @@ tests/
 The **library** (`_evohome`, `evohomeasync`, `evohomeasync2`) is the published
 deliverable. The CLI is a developer convenience and is explicitly excluded from
 code coverage.
+
+---
+
+## Branch model
+
+```text
+feat/my-change  →  dev  →  main  →  tag  →  PyPI
+```
+
+- **Branch off `dev`, and target `dev`** with your PR. Do not target `main`: it is the release
+  boundary, and only the maintainer merges `dev` → `main`.
+- Both branches are protected. All changes arrive via PR — nobody pushes directly — and
+  `lint-ok`, `test-ok` and `type-ok` must be green before a PR can merge. These are stable
+  sentinel checks; the per-version matrix jobs (`test (3.13.x)` &c.) are not required individually.
+- Feature PRs are **squash-merged**, so a messy branch history is fine — write the PR title as you
+  want it to read in the release notes.
+- Keep your branch up to date with `dev`; a rebase may be needed before merging.
+- Home Assistant integration tests do **not** run on `dev` PRs (they are path-filtered and only
+  run against `main`), so a green `dev` PR does not by itself prove HA compatibility.
+
+The release procedure, PR labels and the merge strategy for `dev` → `main` are documented
+separately in [`.github/RELEASING.md`](.github/RELEASING.md).
 
 ---
 


### PR DESCRIPTION
Documents the branch model and merge strategy in two places:

- **`CONTRIBUTING.md`** — new "Branch model" section explaining the `feat → dev → main → tag → PyPI` flow, squash-merge discipline, and pointer to `RELEASING.md`.
- **`.github/RELEASING.md`** — new "Merge strategy" table, new "Branch protection" section (rulesets vs classic rules, the `hass-ok` carve-out), and rewrites "Reset dev" as "Sync dev with main" to explain why a merge commit is used and what breaks if it's ever squashed.