### PR TITLE
chore: tidy the .vscode workspace config

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,8 @@
+// Rules for DavidAnson.vscode-markdownlint (see .vscode/extensions.json).
+// Nothing gates markdown in CI, so this exists to keep the editor's warnings
+// signal rather than noise: the two rules below account for 283 of the 284
+// violations, and neither reflects a defect in these docs.
+{
+  "MD013": false, // line-length: prose is one-sentence-per-line, up to 241 chars
+  "MD060": false  // table-column-style: the tables are not padded to a grid
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,12 +2,24 @@
   "recommendations": [
     "charliermarsh.ruff",
     "DavidAnson.vscode-markdownlint",
-    "esbenp.prettier-vscode",
-    "matangover.mypy-type-checker",
+    "github.vscode-github-actions",
+    "ms-python.mypy-type-checker",
     "ms-python.python",
     "redhat.vscode-yaml",
     "streetsidesoftware.code-spell-checker",
-    "tamasfe.even-better-toml",
-    // "yzhang.markdown-all-in-one"
+    "tamasfe.even-better-toml"
+  ],
+
+  // This project lints & formats with ruff alone: black/flake8/isort/pylint would
+  // double up, with conflicting diagnostics and formatters (see pyproject.toml,
+  // [tool.ruff]). Prettier is superfluous - redhat.vscode-yaml embeds its own, and
+  // JSON has VS Code's built-in - and VS Code would otherwise suggest it, given all
+  // the .json/.yaml/.md here. See the note on [json] in settings.json.
+  "unwantedRecommendations": [
+    "esbenp.prettier-vscode",
+    "ms-python.black-formatter",
+    "ms-python.flake8",
+    "ms-python.isort",
+    "ms-python.pylint"
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,7 +4,6 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
-    
         {
             "name": "Python Debugger: Remote Attach",
             "type": "debugpy",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,35 @@
     // Editor/project consistency
 
     "editor.rulers": [88, 120], // default: []
-    "files.trimTrailingWhitespace": true, // default: false
+
+    // Trailing whitespace is trimmed per-language (below), not globally: the syrupy
+    // snapshots in tests/tests/__snapshots__/*.ambr carry significant trailing
+    // whitespace inside their triple-quoted payloads, so trimming it fails the
+    // comparison (cf. the disabled end-of-file-fixer in .pre-commit-config.yaml).
+    // Markdown is excluded too - a trailing double-space is a hard line break.
+    "files.trimTrailingWhitespace": false, // default: false
+
+    // The watcher is not .gitignore-aware (unlike search, via search.useIgnoreFiles)
+    "files.watcherExclude": {
+        "**/.mypy_cache/**": true,
+        "**/.pytest_cache/**": true,
+        "**/.ruff_cache/**": true,
+        "**/.venv/**": true,
+        "**/dist/**": true
+    },
+
+    // Python interpreter: always this project's uv-managed venv. Without this, the
+    // machine-level default ("/bin/python3") wins, so nothing gets activated in a
+    // terminal and pyenv's shims resolve `ruff`/`mypy` instead. See README.md.
+    "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+    "python.terminal.activateEnvironment": true, // default: true
+
+    // Lint/type tools must be the venv's, so the editor agrees with CI: ruff honours
+    // required-version >= 0.16, and mypy honours python_version = 3.14 (see CLAUDE.md)
+    "ruff.importStrategy": "fromEnvironment", // default: "fromEnvironment" - explicit
+    "mypy-type-checker.importStrategy": "fromEnvironment", // default: "useBundled"
+    "mypy-type-checker.preferDaemon": true, // default: false - dmypy, much faster
+    "mypy-type-checker.reportingScope": "workspace", // default: "file" - match the CLI
 
     // Python analysis and formatting (project-wide)
     "python.analysis.extraPaths": ["src"],
@@ -17,51 +45,68 @@
     "python.testing.pytestEnabled": true,
     "python.testing.unittestEnabled": false,
 
-    // Editor formatting for project files
+    // Editor formatting for project files. There is deliberately no prettier here:
+    // JSON has VS Code's built-in formatter (which, unlike prettier, honours
+    // editor.tabSize - the 4-space vendor fixtures under tests/ must not be
+    // reflowed), redhat.vscode-yaml embeds its own prettier for YAML, and markdown
+    // is hand-formatted (markdownlint lints it, but registers no formatter).
+    // Pinned here rather than left to each contributor's personal formatOnSave, so
+    // that saving a *.py always agrees with `ruff format` / the isort rules in
+    // [tool.ruff.lint.isort]. Note source.fixAll.ruff is deliberately absent: it
+    // would also strip imports you have not finished using yet.
     "[python]": {
+        "editor.codeActionsOnSave": {
+            "source.organizeImports.ruff": "explicit" // i.e. on ^S, not on autosave
+        },
         "editor.defaultFoldingRangeProvider": "charliermarsh.ruff",
-        "editor.defaultFormatter": "charliermarsh.ruff" // default: undefined
+        "editor.defaultFormatter": "charliermarsh.ruff", // default: undefined
+        "editor.formatOnSave": true, // default: false
+        "files.trimTrailingWhitespace": true
     },
-    "[json][jsonc][markdown][yaml]": {
-        "editor.defaultFormatter": "esbenp.prettier-vscode" // default: undefined
+    "[json][jsonc]": {
+        "editor.defaultFormatter": "vscode.json-language-features" // default: undefined
+    },
+    "[yaml]": {
+        "editor.defaultFormatter": "redhat.vscode-yaml", // default: undefined
+        "files.trimTrailingWhitespace": true
     },
     "[toml]": {
-        "editor.defaultFormatter": "tamasfe.even-better-toml" // default: undefined
+        "editor.defaultFormatter": "tamasfe.even-better-toml", // default: undefined
+        "files.trimTrailingWhitespace": true
     },
 
     // Spelling settings
     "cSpell.language": "en-GB",
+    // cSpell enables its python dictionary by languageId, so without this, python
+    // vocabulary (asyncio, noqa, pytest, ...) is unknown in .md/.yaml/.toml files
+    "cSpell.dictionaries": ["python"], // default: []
     "cSpell.ignorePaths": [
         ".vscode/**",
-        "src/_evohome/windows_zones.py",
+        "src/_evohome/windows_zones.*", // the .xml is ~200 timezone/city names
+        "tests/tests/fixtures*/**", // real user data & timezones: place names, rarely en-GB
+        "tests/**/__snapshots__/**", // ditto, as serialized into the snapshots
         "pyproject.toml",
     ],
+    // Only words that cSpell's own en-GB/python/software-terms dictionaries lack:
+    // do not add words it already knows (e.g. asyncio, noqa, pytest, timezone)
     "cSpell.words": [
-        "aiofiles",
         "aiohasupervisor",
-        "aiohttp",
         "aioresponses",
         "aiozoneinfo",
         "ambr",
         "asyncclick",
-        "asyncio",
-        "autochangeover",
         "autolabeler",
         "autouse",
         "cancelable",
         "caplog",
-        "codespell",
         "commtask",
-        "conftest",
         "CRED",
         "CREDS",
-        "dataclasses",
-        "datetimes",
         "dayoff",
+        "datetimes",
         "deadband",
         "dehum",
         "dtms",
-        "elif",
         "EMEA",
         "endoflife",
         "evohome",
@@ -69,35 +114,23 @@
         "evohomeclient",
         "evohomeclientv2",
         "falsey",
-        "firstname",
         "gwys",
         "hass",
-        "hassio",
         "heatingoff",
         "homeassistant",
         "hotwater",
-        "lastname",
         "macid",
         "metafunc",
         "mqtt",
-        "mypy",
-        "noqa",
         "Opentherm",
+        "outdoot", // sic: the vendor's own misspelling, in schemas.py & typedefs.py
         "paho",
-        "pathlib",
         "prek",
-        "pycache",
-        "pydantic",
-        "pyproject",
-        "pytest",
         "redef",
-        "Redlink",
         "Resideo",
-        "ruff",
         "searchforcontractors",
         "securityquestion",
         "setpoints",
-        "setpt",
         "somecomfort",
         "streetaddress",
         "switchpoint",
@@ -105,12 +138,7 @@
         "tccna",
         "tcss",
         "testpaths",
-        "timedelta",
-        "timezone",
-        "timimg",
-        "vars",
         "vendored",
-        "venv",
         "websession",
         "Wifi",
         "YMMV"

--- a/tests/tests/fixtures_v0/README.md
+++ b/tests/tests/fixtures_v0/README.md
@@ -30,6 +30,7 @@ token that should never be hardcoded in test fixtures.
 ## PII policy
 
 All personally identifiable data has been removed or replaced:
+
 - Names → `"John"` / `"Smith"`
 - Usernames → `"user_{userId}@gmail.com"`
 - Addresses → `"1 Main Street"` / city from timezone


### PR DESCRIPTION
Review of the three `.vscode/*.json` files, plus the config they imply.

## Fixes

**`files.trimTrailingWhitespace` would corrupt the syrupy snapshots.** Both `tests/tests/__snapshots__/*.ambr` carry significant trailing whitespace *inside* their triple-quoted payloads, so opening and saving either one in VS Code fails the comparison. `.pre-commit-config.yaml` already knows this (`# id: end-of-file-fixer  # not for snapshots`) but the editor setting did not. Now enabled per-language instead — and not for markdown, where a trailing double-space is a hard line break.

**Prettier was the default formatter for `[json]`, and the fixtures are 4-space.** Prettier's `tabWidth` defaults to 2 and there is no `.prettierrc`/`.prettierignore` here, so format-on-save on a `tests/tests/fixtures_v0/**` file — real vendor debug data feeding the snapshots — rewrote the whole file. `[json]` now points at VS Code's built-in formatter, which honours `editor.tabSize`.

## Extensions

| | |
|---|---|
| + `github.vscode-github-actions` | 8 workflows and `.github/scripts/`; validates expressions and action inputs, which `redhat.vscode-yaml` cannot |
| + `unwantedRecommendations` | black/flake8/isort/pylint conflict with ruff; prettier would otherwise be re-suggested by VS Code, given all the `.md`/`.yaml`/`.json` here |
| − `esbenp.prettier-vscode` | `redhat.vscode-yaml` embeds its own prettier, JSON has the built-in formatter, and markdown is hand-formatted |
| − `// yzhang.markdown-all-in-one` | commented-out; it fights both prettier and markdownlint over markdown |

## Spelling

Kept cSpell — `# cspell:ignore` directives are already in use in the workflows, and en-GB matters here.

The word list goes **77 → 51**. cSpell enables its python dictionary *by languageId*, so python vocabulary was unknown in `.md`/`.yaml`/`.toml` and had been added by hand; `cSpell.dictionaries: ["python"]` enables it workspace-wide, after which 26 entries are redundant. A further 6 appear nowhere in the repo — one of them, `timimg`, was a typo being permanently whitelisted.

`ignorePaths` gains `windows_zones.*` (the `.py` was ignored, but the ~200 timezone and city names are in the `.xml` beside it) and the fixtures/snapshots, which are real user data full of non-en-GB room and street names.

**249 unknown words → 18**, all pre-existing.

## Markdown

`.markdownlint.jsonc` disables `MD013` (line-length) and `MD060` (table-column-style) — 283 of 284 violations, neither reflecting a defect in these docs. Nothing gates markdown in CI, so this keeps the editor's warnings signal rather than noise. **284 → 0**, after fixing the one real `MD032`.

## Also

`formatOnSave` and `source.organizeImports.ruff` pinned for `[python]`, so saving agrees with `ruff format` and `[tool.ruff.lint.isort]` rather than varying per contributor. `source.fixAll.ruff` deliberately omitted. Cache and `.venv` exclusions added for the file watcher, which unlike search is not `.gitignore`-aware.

`ruff check`, `ruff format --check` and `mypy` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)